### PR TITLE
implementing fluentEmit and EventEmitter operators

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -173,6 +173,14 @@
       "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
       "dev": true
     },
+    "@babel/runtime": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+      "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@babel/template": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
@@ -1718,6 +1726,14 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
+    },
+    "for-emit-of": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/for-emit-of/-/for-emit-of-1.2.0.tgz",
+      "integrity": "sha512-vfK5mAH4RI5LtmpQN2GnF0ytS8rXdOGKuQTiGfJ0LgS7bqkyN+Ot2tn2KfkwAubEWsllXPc5Bmi3AObwuNkbGw==",
+      "requires": {
+        "@babel/runtime": "^7.11.2"
+      }
     },
     "foreground-child": {
       "version": "2.0.0",
@@ -3459,6 +3475,11 @@
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
       "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
       "dev": true
+    },
+    "regenerator-runtime": {
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "regexpp": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
   "license": "MIT",
   "dependencies": {
     "augmentative-iterable": "^1.0.0",
-    "extension-methods": "^1.0.0"
+    "extension-methods": "^1.0.0",
+    "for-emit-of": "^1.2.0"
   },
   "devDependencies": {
     "@codibre/confs": "0.0.6",

--- a/src/emitter/combine-emitter.ts
+++ b/src/emitter/combine-emitter.ts
@@ -1,0 +1,24 @@
+import { AnyIterable, Mapper } from 'augmentative-iterable';
+import { combineAsync } from '../async';
+import { EventEmitter } from 'events';
+import { FluentEmitOptions } from '../types';
+import { forEmitOf } from '../for-emit-of';
+
+export function combineEmitter<T>(
+  this: AnyIterable<T>,
+  eventEmitter: EventEmitter,
+  optionsOrKeyA?: FluentEmitOptions | Mapper<any, any>,
+  keyB?: Mapper<any, any>,
+  options?: FluentEmitOptions,
+) {
+  if (!keyB && typeof optionsOrKeyA !== 'function') {
+    options = optionsOrKeyA as FluentEmitOptions;
+    optionsOrKeyA = undefined;
+  }
+  return combineAsync.call(
+    this,
+    forEmitOf(eventEmitter, { ...options }),
+    optionsOrKeyA as Mapper<any, any>,
+    keyB,
+  );
+}

--- a/src/emitter/concat-emitter.ts
+++ b/src/emitter/concat-emitter.ts
@@ -1,0 +1,14 @@
+import { iterateAllAsync } from '../utils';
+import { AnyIterable } from 'augmentative-iterable';
+import { concatAsync } from '../async';
+import { EventEmitter } from 'events';
+import { FluentEmitOptions } from '../types';
+import { forEmitOf } from '../for-emit-of';
+
+export function concatEmitter<T>(
+  this: AnyIterable<T>,
+  eventEmitter: EventEmitter,
+  options?: FluentEmitOptions,
+) {
+  return concatAsync.call(this, forEmitOf(eventEmitter, { ...options }));
+}

--- a/src/emitter/index.ts
+++ b/src/emitter/index.ts
@@ -1,0 +1,4 @@
+export * from './combine-emitter';
+export * from './concat-emitter';
+export * from './merge-emitter';
+export * from './merge-emitter-catching';

--- a/src/emitter/merge-emitter-catching.ts
+++ b/src/emitter/merge-emitter-catching.ts
@@ -1,0 +1,17 @@
+import { EventEmitter } from 'events';
+import { FluentEmitOptions, ErrorCallback } from '../types';
+import { mergeCatching } from '../async-base';
+import { forEmitOf } from '../for-emit-of';
+
+export function mergeEmitterCatching<T>(
+  this: AsyncIterable<T>,
+  errorCallback: ErrorCallback,
+  eventEmitter: EventEmitter,
+  options?: FluentEmitOptions,
+) {
+  return mergeCatching.call(
+    this,
+    errorCallback,
+    forEmitOf(eventEmitter, { ...options }),
+  );
+}

--- a/src/emitter/merge-emitter.ts
+++ b/src/emitter/merge-emitter.ts
@@ -1,0 +1,12 @@
+import { EventEmitter } from 'events';
+import { FluentEmitOptions } from '../types';
+import { merge } from '../async-base';
+import { forEmitOf } from '../for-emit-of';
+
+export function mergeEmitter<T>(
+  this: AsyncIterable<T>,
+  eventEmitter: EventEmitter,
+  options?: FluentEmitOptions,
+) {
+  return merge.call(this, forEmitOf(eventEmitter, { ...options }));
+}

--- a/src/extend-async.ts
+++ b/src/extend-async.ts
@@ -1,7 +1,7 @@
 import { mountIterableFunctions } from './mounters';
 import { addCustomMethod } from './add-custom-method';
 import { AnyIterable } from 'augmentative-iterable';
-import fluentAsync, { proxyReference } from './fluent-async';
+import { fluentAsync, proxyReference } from './fluent-async';
 
 /**
  * An operation that returns an AsyncIterable

--- a/src/extend.ts
+++ b/src/extend.ts
@@ -3,7 +3,7 @@ import { addCustomMethod } from './add-custom-method';
 import { AnyIterable } from 'augmentative-iterable';
 import { proxyReference } from './fluent';
 import { fluent } from '.';
-import fluentAsync from './fluent-async';
+import { fluentAsync } from './fluent-async';
 
 /**
  * An operation that returns an Iterable

--- a/src/fluent-async.ts
+++ b/src/fluent-async.ts
@@ -1,4 +1,4 @@
-import { FluentAsyncIterable } from './types';
+import { FluentAsyncIterable, FluentEmitOptions } from './types';
 import {
   asyncIterableFuncs,
   asyncResolvingFuncs,
@@ -8,6 +8,8 @@ import { mountIterableFunctions, mountSpecial } from './mounters';
 import { AnyIterable } from 'augmentative-iterable';
 import { iterateAsync } from './utils';
 import { getExtender, extend, defaultCookFunction } from 'extension-methods';
+import { EventEmitter } from 'events';
+import { forEmitOf } from './for-emit-of';
 
 export const proxyReference: { [key: string]: Function } = {};
 const handler = getExtender(proxyReference, defaultCookFunction, 'extender');
@@ -24,10 +26,27 @@ function fluentAsync<T>(
   return extend(iterateAsync(iterable), handler) as any;
 }
 
+/**
+ * Tranforms an EventEmitter into a [[FluentAsyncIterable]].
+ * @typeparam T The type of the items in the created FluentAsyncIterable.
+ * @param emitter The EventEmitter
+ * @param options The EventEmitter options. Optional
+ * @returns The [[FluentAsyncIterable]] instance.
+ */
+function fluentEmit<T = any>(
+  emitter: EventEmitter,
+  options?: FluentEmitOptions,
+): FluentAsyncIterable<T> {
+  return extend(
+    forEmitOf<T>(emitter, { ...options }),
+    handler,
+  ) as any;
+}
+
 Object.assign(proxyReference, {
   ...mountIterableFunctions(asyncIterableFuncs, fluentAsync),
   ...mountSpecial(asyncSpecial, fluentAsync, fluentAsync),
   ...asyncResolvingFuncs,
 });
 
-export default fluentAsync;
+export { fluentAsync, fluentEmit };

--- a/src/fluent.ts
+++ b/src/fluent.ts
@@ -1,4 +1,4 @@
-import fluentAsync from './fluent-async';
+import { fluentAsync } from './fluent-async';
 import { FluentIterable } from './types';
 import {
   iterableFuncs,

--- a/src/for-emit-of.ts
+++ b/src/for-emit-of.ts
@@ -1,0 +1,3 @@
+import lib = require('for-emit-of');
+
+export const forEmitOf = (lib as unknown) as typeof lib.default;

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import {
 } from './types';
 
 import fluent from './fluent';
-import fluentAsync from './fluent-async';
+import { fluentAsync, fluentEmit } from './fluent-async';
 import depaginate from './depaginator';
 import { interval } from './interval';
 import { mergeIterators } from './async-base/merging';
@@ -43,6 +43,7 @@ export {
   Pager,
   fluent,
   fluentAsync,
+  fluentEmit,
   depaginate,
   interval,
   mergeIterators,

--- a/src/mounters/fluent-async-functions.ts
+++ b/src/mounters/fluent-async-functions.ts
@@ -41,6 +41,12 @@ import {
   filterAsync,
   mapAsync,
 } from '../async';
+import {
+  combineEmitter,
+  concatEmitter,
+  mergeEmitter,
+  mergeEmitterCatching,
+} from '../emitter';
 import { merge, mergeCatching } from '../async-base';
 
 export const asyncIterableFuncs = {
@@ -67,6 +73,10 @@ export const asyncIterableFuncs = {
   merge,
   mergeCatching,
   combine: combineAsync,
+  combineEmitter,
+  concatEmitter,
+  mergeEmitter,
+  mergeEmitterCatching,
 };
 
 export const asyncSpecial = {

--- a/src/mounters/fluent-functions.ts
+++ b/src/mounters/fluent-functions.ts
@@ -69,6 +69,7 @@ import {
   filterAsync,
   takeWhileAsync,
 } from '../async';
+import { combineEmitter, concatEmitter } from '../emitter';
 
 export const iterableFuncs = {
   withIndex,
@@ -100,6 +101,8 @@ export const iterableAsyncFuncs = {
   executeAsync,
   toAsync,
   combineAsync,
+  combineEmitter,
+  concatEmitter,
 };
 
 export const special = {

--- a/test/combine.spec.ts
+++ b/test/combine.spec.ts
@@ -170,6 +170,89 @@ describe('combine', () => {
     });
   });
 
+  context('fluent.combineEmitter', async () => {
+    it('should join an iterable and an Emitter as an NxN combination', async () => {
+      const result = await fluent([1, 2, 3])
+        .combineEmitter(new ObjectReadableMock(['a', 'b', 'c']))
+        .toArray();
+
+      expect(result).to.be.eql(expected);
+    });
+
+    it('should join two iterables resulting in the matching combinations when key expressions are provided', async () => {
+      const result = await fluent([1, 2])
+        .combineEmitter(
+          new ObjectReadableMock(['a', 'b']),
+          constant(1),
+          constant(1),
+        )
+        .toArray();
+
+      expect(result).to.be.eql([
+        [1, 'a'],
+        [1, 'b'],
+        [2, 'a'],
+        [2, 'b'],
+      ]);
+    });
+
+    it('should join two iterables resulting in the matching combinations when key expressions are provided', async () => {
+      const result = await fluent([1, 2, 3])
+        .combineEmitter(
+          new ObjectReadableMock(['a', 'b', 'c', 'd']),
+          (a) => a,
+          (b) => {
+            switch (b) {
+              case 'd':
+                return 1;
+              case 'b':
+              case 'c':
+                return 2;
+              default:
+                return 4;
+            }
+          },
+        )
+        .toArray();
+
+      expect(result).to.be.eql([
+        [1, 'd'],
+        [2, 'b'],
+        [2, 'c'],
+      ]);
+    });
+
+    it('should throw an error when only keyA is provided', () => {
+      let error: any;
+      try {
+        fluent([1, 2, 3]).combineEmitter(
+          new ObjectReadableMock(['a', 'b', 'c', 'd']),
+          identity,
+          undefined as any,
+        );
+      } catch (err) {
+        error = err;
+      }
+
+      expect(error).to.be.instanceOf(Error);
+    });
+
+    it('should throw an error when only keyB is provided', () => {
+      let error: any;
+      try {
+        fluent([1, 2, 3]).combineEmitter(
+          new ObjectReadableMock(['a', 'b', 'c', 'd']),
+          undefined as any,
+          identity,
+        );
+      } catch (err) {
+        error = err;
+      }
+
+      expect(error).to.be.instanceOf(Error);
+    });
+  });
+
   context('fluentAsync.combine', async () => {
     it('should join two async iterables as an NxN combination', async () => {
       const result = await fluentAsync(new ObjectReadableMock([1, 2, 3]))
@@ -245,6 +328,89 @@ describe('combine', () => {
       let error: any;
       try {
         fluentAsync([1, 2, 3]).combine(
+          new ObjectReadableMock(['a', 'b', 'c', 'd']),
+          undefined as any,
+          identity,
+        );
+      } catch (err) {
+        error = err;
+      }
+
+      expect(error).to.be.instanceOf(Error);
+    });
+  });
+
+  context('fluentAsync.combineEmitter', async () => {
+    it('should join two async iterables as an NxN combination', async () => {
+      const result = await fluentAsync(new ObjectReadableMock([1, 2, 3]))
+        .combineEmitter(new ObjectReadableMock(['a', 'b', 'c']))
+        .toArray();
+
+      expect(result).to.be.eql(expected);
+    });
+
+    it('should join two iterables resulting in the matching combinations when key expressions are provided', async () => {
+      const result = await fluentAsync([1, 2])
+        .combineEmitter(
+          new ObjectReadableMock(['a', 'b']),
+          constant(1),
+          constant(1),
+        )
+        .toArray();
+
+      expect(result).to.be.eql([
+        [1, 'a'],
+        [1, 'b'],
+        [2, 'a'],
+        [2, 'b'],
+      ]);
+    });
+
+    it('should join two iterables resulting in the matching combinations when key expressions are provided', async () => {
+      const result = await fluentAsync([1, 2, 3])
+        .combineEmitter(
+          new ObjectReadableMock(['a', 'b', 'c', 'd']),
+          (a) => a,
+          (b) => {
+            switch (b) {
+              case 'd':
+                return 1;
+              case 'b':
+              case 'c':
+                return 2;
+              default:
+                return 4;
+            }
+          },
+        )
+        .toArray();
+
+      expect(result).to.be.eql([
+        [1, 'd'],
+        [2, 'b'],
+        [2, 'c'],
+      ]);
+    });
+
+    it('should throw an error when only keyA is provided', () => {
+      let error: any;
+      try {
+        fluentAsync([1, 2, 3]).combineEmitter(
+          new ObjectReadableMock(['a', 'b', 'c', 'd']),
+          identity,
+          undefined as any,
+        );
+      } catch (err) {
+        error = err;
+      }
+
+      expect(error).to.be.instanceOf(Error);
+    });
+
+    it('should throw an error when only keyB is provided', () => {
+      let error: any;
+      try {
+        fluentAsync([1, 2, 3]).combineEmitter(
           new ObjectReadableMock(['a', 'b', 'c', 'd']),
           undefined as any,
           identity,

--- a/test/fluent.spec.ts
+++ b/test/fluent.spec.ts
@@ -3,6 +3,7 @@ import expect, { flatMap, pick } from './tools';
 import delay from 'delay';
 import { stub } from 'sinon';
 import 'chai-callslike';
+import { ObjectReadableMock } from 'stream-mock';
 
 export enum Gender {
   Male = 'Male',
@@ -407,6 +408,21 @@ describe('fluent iterable', () => {
         it('one empty and one non-empty arrays', () =>
           expect(
             fluent(subject).concat([], [additionalPerson]).toArray(),
+          ).to.eql([...data, additionalPerson]));
+      });
+
+      describe('concatEmitter', () => {
+        it('one empty array', async () =>
+          expect(
+            await fluent(subject)
+              .concatEmitter(new ObjectReadableMock([]))
+              .toArray(),
+          ).to.eql(data));
+        it('one non-empty arrays', async () =>
+          expect(
+            await fluent(subject)
+              .concatEmitter(new ObjectReadableMock([additionalPerson]))
+              .toArray(),
           ).to.eql([...data, additionalPerson]));
       });
       describe('repeat', () => {


### PR DESCRIPTION
Closes #10 

A new method is implemented called **fluentEmit**, which works like a wrapper for [for-emit-of](https://github.com/danstarns/for-emit-of) library, that creates an AsyncIterable from an EventEmitter.

Also, some operations that received an AsyncIterable got a new version receiving an EventEmitter and, optionally, its options.

So, these changes allow us to treat an EventEmitter as an AsyncIterable and to apply all the already implemented operations to them, which open possibilities for:
* To create a workflow that, for each event received, all the chained operations are executed;
* To create an async workflow that will execute all the chained operations but will not be executed until the previous one are finished;
* To merge or combine Iterables, AsyncIterables, and EventEmitters seamlessly;
 