### PR TITLE
Fixing to object return type with key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 
-## 1.7.3
+## 1.7.4
+* c4fa462 1.7.3
 * 107736b Fixing to-object object type when key string is used
 * e7a095a Issue 26 bug with typing when flatten uses string field property (#28)
 ## v1.7.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 
-## 1.7.2
+## 1.7.3
+* 107736b Fixing to-object object type when key string is used
+* e7a095a Issue 26 bug with typing when flatten uses string field property (#28)
+## v1.7.4
+* 9e5bfa9 1.7.4
+* 88a79f8 fixing typing for async flatten
+## v1.7.3
+* 82f9310 1.7.3
+* 326de0b fixing type of flatten with no parameters
+* dc6391a updating typedoc
+## v1.7.2
+* e6d4211 1.7.2
 * 1e2e8f7 Fixing return type of flatten
 * 2dde58d Release (#24)
 * 82f25ea Release (#23)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 
-## 1.7.4
+## 1.7.5
+* adbd564 1.7.4
 * c4fa462 1.7.3
 * 107736b Fixing to-object object type when key string is used
 * e7a095a Issue 26 bug with typing when flatten uses string field property (#28)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
-**[fluent-iterable - v1.7.4](README.md)**
+**[fluent-iterable - v1.7.5](README.md)**
 
 > Globals
 
-# fluent-iterable - v1.7.4
+# fluent-iterable - v1.7.5
 
 ## Index
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
-**[fluent-iterable - v1.7.3](README.md)**
+**[fluent-iterable - v1.7.4](README.md)**
 
 > Globals
 
-# fluent-iterable - v1.7.3
+# fluent-iterable - v1.7.4
 
 ## Index
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
-**[fluent-iterable - v1.7.2](README.md)**
+**[fluent-iterable - v1.7.3](README.md)**
 
 > Globals
 
-# fluent-iterable - v1.7.2
+# fluent-iterable - v1.7.3
 
 ## Index
 

--- a/docs/interfaces/_assure_order_types_.orderassurable.md
+++ b/docs/interfaces/_assure_order_types_.orderassurable.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / ["assure-order-types"](../modules/_assure_order_types_.md) / OrderAssurable
 

--- a/docs/interfaces/_assure_order_types_.orderassurable.md
+++ b/docs/interfaces/_assure_order_types_.orderassurable.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / ["assure-order-types"](../modules/_assure_order_types_.md) / OrderAssurable
 

--- a/docs/interfaces/_assure_order_types_.orderassurable.md
+++ b/docs/interfaces/_assure_order_types_.orderassurable.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / ["assure-order-types"](../modules/_assure_order_types_.md) / OrderAssurable
 

--- a/docs/interfaces/_async_base_merging_merge_types_.getnextasynciterator.md
+++ b/docs/interfaces/_async_base_merging_merge_types_.getnextasynciterator.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / ["async-base/merging/merge-types"](../modules/_async_base_merging_merge_types_.md) / GetNextAsyncIterator
 

--- a/docs/interfaces/_async_base_merging_merge_types_.getnextasynciterator.md
+++ b/docs/interfaces/_async_base_merging_merge_types_.getnextasynciterator.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / ["async-base/merging/merge-types"](../modules/_async_base_merging_merge_types_.md) / GetNextAsyncIterator
 

--- a/docs/interfaces/_async_base_merging_merge_types_.getnextasynciterator.md
+++ b/docs/interfaces/_async_base_merging_merge_types_.getnextasynciterator.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / ["async-base/merging/merge-types"](../modules/_async_base_merging_merge_types_.md) / GetNextAsyncIterator
 

--- a/docs/interfaces/_async_base_merging_merge_types_.nextresult.md
+++ b/docs/interfaces/_async_base_merging_merge_types_.nextresult.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / ["async-base/merging/merge-types"](../modules/_async_base_merging_merge_types_.md) / NextResult
 

--- a/docs/interfaces/_async_base_merging_merge_types_.nextresult.md
+++ b/docs/interfaces/_async_base_merging_merge_types_.nextresult.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / ["async-base/merging/merge-types"](../modules/_async_base_merging_merge_types_.md) / NextResult
 

--- a/docs/interfaces/_async_base_merging_merge_types_.nextresult.md
+++ b/docs/interfaces/_async_base_merging_merge_types_.nextresult.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / ["async-base/merging/merge-types"](../modules/_async_base_merging_merge_types_.md) / NextResult
 

--- a/docs/interfaces/_types_.fluentasynciterable.md
+++ b/docs/interfaces/_types_.fluentasynciterable.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / ["types"](../modules/_types_.md) / FluentAsyncIterable
 

--- a/docs/interfaces/_types_.fluentasynciterable.md
+++ b/docs/interfaces/_types_.fluentasynciterable.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / ["types"](../modules/_types_.md) / FluentAsyncIterable
 

--- a/docs/interfaces/_types_.fluentasynciterable.md
+++ b/docs/interfaces/_types_.fluentasynciterable.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / ["types"](../modules/_types_.md) / FluentAsyncIterable
 

--- a/docs/interfaces/_types_.fluentgroup.md
+++ b/docs/interfaces/_types_.fluentgroup.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / ["types"](../modules/_types_.md) / FluentGroup
 

--- a/docs/interfaces/_types_.fluentgroup.md
+++ b/docs/interfaces/_types_.fluentgroup.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / ["types"](../modules/_types_.md) / FluentGroup
 

--- a/docs/interfaces/_types_.fluentgroup.md
+++ b/docs/interfaces/_types_.fluentgroup.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / ["types"](../modules/_types_.md) / FluentGroup
 

--- a/docs/interfaces/_types_.fluentiterable.md
+++ b/docs/interfaces/_types_.fluentiterable.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / ["types"](../modules/_types_.md) / FluentIterable
 

--- a/docs/interfaces/_types_.fluentiterable.md
+++ b/docs/interfaces/_types_.fluentiterable.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / ["types"](../modules/_types_.md) / FluentIterable
 

--- a/docs/interfaces/_types_.fluentiterable.md
+++ b/docs/interfaces/_types_.fluentiterable.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / ["types"](../modules/_types_.md) / FluentIterable
 

--- a/docs/interfaces/_types_.page.md
+++ b/docs/interfaces/_types_.page.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / ["types"](../modules/_types_.md) / Page
 

--- a/docs/interfaces/_types_.page.md
+++ b/docs/interfaces/_types_.page.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / ["types"](../modules/_types_.md) / Page
 

--- a/docs/interfaces/_types_.page.md
+++ b/docs/interfaces/_types_.page.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / ["types"](../modules/_types_.md) / Page
 

--- a/docs/interfaces/_types_.pager.md
+++ b/docs/interfaces/_types_.pager.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / ["types"](../modules/_types_.md) / Pager
 

--- a/docs/interfaces/_types_.pager.md
+++ b/docs/interfaces/_types_.pager.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / ["types"](../modules/_types_.md) / Pager
 

--- a/docs/interfaces/_types_.pager.md
+++ b/docs/interfaces/_types_.pager.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / ["types"](../modules/_types_.md) / Pager
 

--- a/docs/interfaces/_types_base_.action.md
+++ b/docs/interfaces/_types_base_.action.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / Action
 

--- a/docs/interfaces/_types_base_.action.md
+++ b/docs/interfaces/_types_base_.action.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / Action
 

--- a/docs/interfaces/_types_base_.action.md
+++ b/docs/interfaces/_types_base_.action.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / Action
 

--- a/docs/interfaces/_types_base_.asyncaction.md
+++ b/docs/interfaces/_types_base_.asyncaction.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / AsyncAction
 

--- a/docs/interfaces/_types_base_.asyncaction.md
+++ b/docs/interfaces/_types_base_.asyncaction.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / AsyncAction
 

--- a/docs/interfaces/_types_base_.asyncaction.md
+++ b/docs/interfaces/_types_base_.asyncaction.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / AsyncAction
 

--- a/docs/interfaces/_types_base_.asyncreducer.md
+++ b/docs/interfaces/_types_base_.asyncreducer.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / AsyncReducer
 

--- a/docs/interfaces/_types_base_.asyncreducer.md
+++ b/docs/interfaces/_types_base_.asyncreducer.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / AsyncReducer
 

--- a/docs/interfaces/_types_base_.asyncreducer.md
+++ b/docs/interfaces/_types_base_.asyncreducer.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / AsyncReducer
 

--- a/docs/interfaces/_types_base_.averagestepper.md
+++ b/docs/interfaces/_types_base_.averagestepper.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / AverageStepper
 

--- a/docs/interfaces/_types_base_.averagestepper.md
+++ b/docs/interfaces/_types_base_.averagestepper.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / AverageStepper
 

--- a/docs/interfaces/_types_base_.averagestepper.md
+++ b/docs/interfaces/_types_base_.averagestepper.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / AverageStepper
 

--- a/docs/interfaces/_types_base_.comparer.md
+++ b/docs/interfaces/_types_base_.comparer.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / Comparer
 

--- a/docs/interfaces/_types_base_.comparer.md
+++ b/docs/interfaces/_types_base_.comparer.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / Comparer
 

--- a/docs/interfaces/_types_base_.comparer.md
+++ b/docs/interfaces/_types_base_.comparer.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / Comparer
 

--- a/docs/interfaces/_types_base_.equality.md
+++ b/docs/interfaces/_types_base_.equality.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / Equality
 

--- a/docs/interfaces/_types_base_.equality.md
+++ b/docs/interfaces/_types_base_.equality.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / Equality
 

--- a/docs/interfaces/_types_base_.equality.md
+++ b/docs/interfaces/_types_base_.equality.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / Equality
 

--- a/docs/interfaces/_types_base_.errorcallback.md
+++ b/docs/interfaces/_types_base_.errorcallback.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / ErrorCallback
 

--- a/docs/interfaces/_types_base_.errorcallback.md
+++ b/docs/interfaces/_types_base_.errorcallback.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / ErrorCallback
 

--- a/docs/interfaces/_types_base_.errorcallback.md
+++ b/docs/interfaces/_types_base_.errorcallback.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / ErrorCallback
 

--- a/docs/interfaces/_types_base_.fluentemitoptions.md
+++ b/docs/interfaces/_types_base_.fluentemitoptions.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / FluentEmitOptions
 

--- a/docs/interfaces/_types_base_.fluentemitoptions.md
+++ b/docs/interfaces/_types_base_.fluentemitoptions.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / FluentEmitOptions
 

--- a/docs/interfaces/_types_base_.fluentemitoptions.md
+++ b/docs/interfaces/_types_base_.fluentemitoptions.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / FluentEmitOptions
 

--- a/docs/interfaces/_types_base_.fluentemitter.md
+++ b/docs/interfaces/_types_base_.fluentemitter.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / FluentEmitter
 

--- a/docs/interfaces/_types_base_.fluentemitter.md
+++ b/docs/interfaces/_types_base_.fluentemitter.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / FluentEmitter
 

--- a/docs/interfaces/_types_base_.fluentemitter.md
+++ b/docs/interfaces/_types_base_.fluentemitter.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / FluentEmitter
 

--- a/docs/interfaces/_types_base_.fluentevents.md
+++ b/docs/interfaces/_types_base_.fluentevents.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / FluentEvents
 

--- a/docs/interfaces/_types_base_.fluentevents.md
+++ b/docs/interfaces/_types_base_.fluentevents.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / FluentEvents
 

--- a/docs/interfaces/_types_base_.fluentevents.md
+++ b/docs/interfaces/_types_base_.fluentevents.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / FluentEvents
 

--- a/docs/interfaces/_types_base_.group.md
+++ b/docs/interfaces/_types_base_.group.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / Group
 

--- a/docs/interfaces/_types_base_.group.md
+++ b/docs/interfaces/_types_base_.group.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / Group
 

--- a/docs/interfaces/_types_base_.group.md
+++ b/docs/interfaces/_types_base_.group.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / Group
 

--- a/docs/interfaces/_types_base_.indexed.md
+++ b/docs/interfaces/_types_base_.indexed.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / Indexed
 

--- a/docs/interfaces/_types_base_.indexed.md
+++ b/docs/interfaces/_types_base_.indexed.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / Indexed
 

--- a/docs/interfaces/_types_base_.indexed.md
+++ b/docs/interfaces/_types_base_.indexed.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / Indexed
 

--- a/docs/interfaces/_types_base_.reducer.md
+++ b/docs/interfaces/_types_base_.reducer.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / Reducer
 

--- a/docs/interfaces/_types_base_.reducer.md
+++ b/docs/interfaces/_types_base_.reducer.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / Reducer
 

--- a/docs/interfaces/_types_base_.reducer.md
+++ b/docs/interfaces/_types_base_.reducer.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / ["types-base"](../modules/_types_base_.md) / Reducer
 

--- a/docs/interfaces/_types_emitter_.fluentiterableemitter.md
+++ b/docs/interfaces/_types_emitter_.fluentiterableemitter.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / ["types-emitter"](../modules/_types_emitter_.md) / FluentIterableEmitter
 

--- a/docs/interfaces/_types_emitter_.fluentiterableemitter.md
+++ b/docs/interfaces/_types_emitter_.fluentiterableemitter.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / ["types-emitter"](../modules/_types_emitter_.md) / FluentIterableEmitter
 

--- a/docs/interfaces/_types_emitter_.fluentiterableemitter.md
+++ b/docs/interfaces/_types_emitter_.fluentiterableemitter.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / ["types-emitter"](../modules/_types_emitter_.md) / FluentIterableEmitter
 

--- a/docs/interfaces/_types_key_._types_.fluentasynciterable.md
+++ b/docs/interfaces/_types_key_._types_.fluentasynciterable.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / ["types-key"](../modules/_types_key_.md) / ["types"](../modules/_types_key_._types_.md) / FluentAsyncIterable
 

--- a/docs/interfaces/_types_key_._types_.fluentasynciterable.md
+++ b/docs/interfaces/_types_key_._types_.fluentasynciterable.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / ["types-key"](../modules/_types_key_.md) / ["types"](../modules/_types_key_._types_.md) / FluentAsyncIterable
 

--- a/docs/interfaces/_types_key_._types_.fluentasynciterable.md
+++ b/docs/interfaces/_types_key_._types_.fluentasynciterable.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / ["types-key"](../modules/_types_key_.md) / ["types"](../modules/_types_key_._types_.md) / FluentAsyncIterable
 
@@ -533,7 +533,7 @@ ___
 
 ### toObject
 
-▸ **toObject**\<R1, R>(`keySelector`: R1, `valueSelector?`: AsyncMapper\<T, R>): Promise\<any>
+▸ **toObject**\<R1, R>(`keySelector`: R1, `valueSelector?`: AsyncMapper\<T, R>): Promise\<{}>
 
 Translates the iterable into an object using the elements of the iterable as representations of fields as specified by a key- and value selector. This is a resolving operation, will cause a full loop through all the elements of the iterable.
 
@@ -551,11 +551,11 @@ Name | Type | Description |
 `keySelector` | R1 | Projects an element of the iterable into the key of the corresponding field. |
 `valueSelector?` | AsyncMapper\<T, R> | Projects an element of the iterable into the value of the corresponding field. The identity function is being used if omitted. |
 
-**Returns:** Promise\<any>
+**Returns:** Promise\<{}>
 
 A promise of the object composed of the elements of the iterable as fields.
 
-▸ **toObject**\<R2>(`keySelector`: AsyncMapper\<T, any>, `valueSelector`: R2): Promise\<any>
+▸ **toObject**\<K, R2>(`keySelector`: AsyncMapper\<T, K>, `valueSelector`: R2): Promise\<{}>
 
 Translates the iterable into an object using the elements of the iterable as representations of fields as specified by a key- and value selector. This is a resolving operation, will cause a full loop through all the elements of the iterable.
 
@@ -565,20 +565,21 @@ Translates the iterable into an object using the elements of the iterable as rep
 
 Name | Type |
 ------ | ------ |
+`K` | string \| symbol \| number |
 `R2` | keyof T |
 
 #### Parameters:
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`keySelector` | AsyncMapper\<T, any> | Projects an element of the iterable into the key of the corresponding field. |
+`keySelector` | AsyncMapper\<T, K> | Projects an element of the iterable into the key of the corresponding field. |
 `valueSelector` | R2 | Projects an element of the iterable into the value of the corresponding field. The identity function is being used if omitted. |
 
-**Returns:** Promise\<any>
+**Returns:** Promise\<{}>
 
 A promise of the object composed of the elements of the iterable as fields.
 
-▸ **toObject**\<R1, R2>(`keySelector`: R1, `valueSelector`: R2): Promise\<any>
+▸ **toObject**\<R1, R2>(`keySelector`: R1, `valueSelector`: R2): Promise\<{}>
 
 Translates the iterable into an object using the elements of the iterable as representations of fields as specified by a key- and value selector. This is a resolving operation, will cause a full loop through all the elements of the iterable.
 
@@ -598,7 +599,7 @@ Name | Type | Description |
 `keySelector` | R1 | Projects an element of the iterable into the key of the corresponding field. |
 `valueSelector` | R2 | Projects an element of the iterable into the value of the corresponding field. The identity function is being used if omitted. |
 
-**Returns:** Promise\<any>
+**Returns:** Promise\<{}>
 
 A promise of the object composed of the elements of the iterable as fields.
 

--- a/docs/interfaces/_types_key_._types_.fluentiterable.md
+++ b/docs/interfaces/_types_key_._types_.fluentiterable.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / ["types-key"](../modules/_types_key_.md) / ["types"](../modules/_types_key_._types_.md) / FluentIterable
 

--- a/docs/interfaces/_types_key_._types_.fluentiterable.md
+++ b/docs/interfaces/_types_key_._types_.fluentiterable.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / ["types-key"](../modules/_types_key_.md) / ["types"](../modules/_types_key_._types_.md) / FluentIterable
 
@@ -1085,7 +1085,7 @@ ___
 
 ### toObject
 
-▸ **toObject**\<R1, R>(`keySelector`: R1, `valueSelector?`: Mapper\<T, R>): any
+▸ **toObject**\<R1, R>(`keySelector`: R1, `valueSelector?`: Mapper\<T, R>): object
 
 Translates the iterable into an object using the elements of the iterable as representations of fields as specified by a key- and value selector. This is a resolving operation, will cause a full loop through all the elements of the iterable.<br>
   Examples:<br>
@@ -1106,11 +1106,11 @@ Name | Type | Description |
 `keySelector` | R1 | Projects an element of the iterable into the key of the corresponding field. |
 `valueSelector?` | Mapper\<T, R> | Projects an element of the iterable into the value of the corresponding field. The identity function is being used if omitted. |
 
-**Returns:** any
+**Returns:** object
 
 The object composed of the elements of the iterable as fields.
 
-▸ **toObject**\<R2>(`keySelector`: Mapper\<T, any>, `valueSelector`: R2): any
+▸ **toObject**\<K, R2>(`keySelector`: Mapper\<T, K>, `valueSelector`: R2): object
 
 Translates the iterable into an object using the elements of the iterable as representations of fields as specified by a key- and value selector. This is a resolving operation, will cause a full loop through all the elements of the iterable.<br>
   Examples:<br>
@@ -1123,20 +1123,21 @@ Translates the iterable into an object using the elements of the iterable as rep
 
 Name | Type |
 ------ | ------ |
+`K` | string \| symbol \| number |
 `R2` | keyof T |
 
 #### Parameters:
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`keySelector` | Mapper\<T, any> | Projects an element of the iterable into the key of the corresponding field. |
+`keySelector` | Mapper\<T, K> | Projects an element of the iterable into the key of the corresponding field. |
 `valueSelector` | R2 | Projects an element of the iterable into the value of the corresponding field. The identity function is being used if omitted. |
 
-**Returns:** any
+**Returns:** object
 
 The object composed of the elements of the iterable as fields.
 
-▸ **toObject**\<R1, R2>(`keySelector`: R1, `valueSelector`: R2): any
+▸ **toObject**\<R1, R2>(`keySelector`: R1, `valueSelector`: R2): object
 
 Translates the iterable into an object using the elements of the iterable as representations of fields as specified by a key- and value selector. This is a resolving operation, will cause a full loop through all the elements of the iterable.<br>
   Examples:<br>
@@ -1159,7 +1160,7 @@ Name | Type | Description |
 `keySelector` | R1 | Projects an element of the iterable into the key of the corresponding field. |
 `valueSelector` | R2 | Projects an element of the iterable into the value of the corresponding field. The identity function is being used if omitted. |
 
-**Returns:** any
+**Returns:** object
 
 The object composed of the elements of the iterable as fields.
 
@@ -1167,7 +1168,7 @@ ___
 
 ### toObjectAsync
 
-▸ **toObjectAsync**\<R1, R>(`keySelector`: R1, `valueSelector?`: AsyncMapper\<T, R>): Promise\<any>
+▸ **toObjectAsync**\<R1, R>(`keySelector`: R1, `valueSelector?`: AsyncMapper\<T, R>): Promise\<{}>
 
 Translates the iterable into an object using the elements of the iterable as representations of fields as specified by an asynchronous key- and value selector. This is a resolving operation, will cause a full loop through all the elements of the iterable.
 
@@ -1185,11 +1186,11 @@ Name | Type | Description |
 `keySelector` | R1 | Asynchronously projects an element of the iterable into the key of the corresponding field. |
 `valueSelector?` | AsyncMapper\<T, R> | Asynchronously projects an element of the iterable into the value of the corresponding field. |
 
-**Returns:** Promise\<any>
+**Returns:** Promise\<{}>
 
 A promise of the object composed of the elements of the iterable as fields.
 
-▸ **toObjectAsync**\<R2>(`keySelector`: AsyncMapper\<T, any>, `valueSelector`: R2): Promise\<any>
+▸ **toObjectAsync**\<K, R2>(`keySelector`: AsyncMapper\<T, K>, `valueSelector`: R2): Promise\<{}>
 
 Translates the iterable into an object using the elements of the iterable as representations of fields as specified by an asynchronous key- and value selector. This is a resolving operation, will cause a full loop through all the elements of the iterable.
 
@@ -1199,20 +1200,21 @@ Translates the iterable into an object using the elements of the iterable as rep
 
 Name | Type |
 ------ | ------ |
+`K` | string \| symbol \| number |
 `R2` | keyof T |
 
 #### Parameters:
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`keySelector` | AsyncMapper\<T, any> | Asynchronously projects an element of the iterable into the key of the corresponding field. |
+`keySelector` | AsyncMapper\<T, K> | Asynchronously projects an element of the iterable into the key of the corresponding field. |
 `valueSelector` | R2 | Asynchronously projects an element of the iterable into the value of the corresponding field. |
 
-**Returns:** Promise\<any>
+**Returns:** Promise\<{}>
 
 A promise of the object composed of the elements of the iterable as fields.
 
-▸ **toObjectAsync**\<R1, R2>(`keySelector`: R1, `valueSelector`: R2): Promise\<any>
+▸ **toObjectAsync**\<R1, R2>(`keySelector`: R1, `valueSelector`: R2): Promise\<{}>
 
 Translates the iterable into an object using the elements of the iterable as representations of fields as specified by an asynchronous key- and value selector. This is a resolving operation, will cause a full loop through all the elements of the iterable.
 
@@ -1232,7 +1234,7 @@ Name | Type | Description |
 `keySelector` | R1 | Asynchronously projects an element of the iterable into the key of the corresponding field. |
 `valueSelector` | R2 | Asynchronously projects an element of the iterable into the value of the corresponding field. |
 
-**Returns:** Promise\<any>
+**Returns:** Promise\<{}>
 
 A promise of the object composed of the elements of the iterable as fields.
 

--- a/docs/interfaces/_types_key_._types_.fluentiterable.md
+++ b/docs/interfaces/_types_key_._types_.fluentiterable.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / ["types-key"](../modules/_types_key_.md) / ["types"](../modules/_types_key_._types_.md) / FluentIterable
 

--- a/docs/modules/_add_custom_method_.md
+++ b/docs/modules/_add_custom_method_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / "add-custom-method"
 

--- a/docs/modules/_add_custom_method_.md
+++ b/docs/modules/_add_custom_method_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / "add-custom-method"
 

--- a/docs/modules/_add_custom_method_.md
+++ b/docs/modules/_add_custom_method_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / "add-custom-method"
 

--- a/docs/modules/_assure_order_types_.md
+++ b/docs/modules/_assure_order_types_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / "assure-order-types"
 

--- a/docs/modules/_assure_order_types_.md
+++ b/docs/modules/_assure_order_types_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / "assure-order-types"
 

--- a/docs/modules/_assure_order_types_.md
+++ b/docs/modules/_assure_order_types_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / "assure-order-types"
 

--- a/docs/modules/_async_base_index_.md
+++ b/docs/modules/_async_base_index_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / "async-base/index"
 

--- a/docs/modules/_async_base_index_.md
+++ b/docs/modules/_async_base_index_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / "async-base/index"
 

--- a/docs/modules/_async_base_index_.md
+++ b/docs/modules/_async_base_index_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / "async-base/index"
 

--- a/docs/modules/_async_base_merge_.md
+++ b/docs/modules/_async_base_merge_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / "async-base/merge"
 

--- a/docs/modules/_async_base_merge_.md
+++ b/docs/modules/_async_base_merge_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / "async-base/merge"
 

--- a/docs/modules/_async_base_merge_.md
+++ b/docs/modules/_async_base_merge_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / "async-base/merge"
 

--- a/docs/modules/_async_base_merge_catching_.md
+++ b/docs/modules/_async_base_merge_catching_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / "async-base/merge-catching"
 

--- a/docs/modules/_async_base_merge_catching_.md
+++ b/docs/modules/_async_base_merge_catching_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / "async-base/merge-catching"
 

--- a/docs/modules/_async_base_merge_catching_.md
+++ b/docs/modules/_async_base_merge_catching_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / "async-base/merge-catching"
 

--- a/docs/modules/_async_base_merging_get_iterators_.md
+++ b/docs/modules/_async_base_merging_get_iterators_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / "async-base/merging/get-iterators"
 

--- a/docs/modules/_async_base_merging_get_iterators_.md
+++ b/docs/modules/_async_base_merging_get_iterators_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / "async-base/merging/get-iterators"
 

--- a/docs/modules/_async_base_merging_get_iterators_.md
+++ b/docs/modules/_async_base_merging_get_iterators_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / "async-base/merging/get-iterators"
 

--- a/docs/modules/_async_base_merging_get_next_async_iterator_.md
+++ b/docs/modules/_async_base_merging_get_next_async_iterator_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / "async-base/merging/get-next-async-iterator"
 

--- a/docs/modules/_async_base_merging_get_next_async_iterator_.md
+++ b/docs/modules/_async_base_merging_get_next_async_iterator_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / "async-base/merging/get-next-async-iterator"
 

--- a/docs/modules/_async_base_merging_get_next_async_iterator_.md
+++ b/docs/modules/_async_base_merging_get_next_async_iterator_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / "async-base/merging/get-next-async-iterator"
 

--- a/docs/modules/_async_base_merging_get_next_async_iterator_factory_.md
+++ b/docs/modules/_async_base_merging_get_next_async_iterator_factory_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / "async-base/merging/get-next-async-iterator-factory"
 

--- a/docs/modules/_async_base_merging_get_next_async_iterator_factory_.md
+++ b/docs/modules/_async_base_merging_get_next_async_iterator_factory_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / "async-base/merging/get-next-async-iterator-factory"
 

--- a/docs/modules/_async_base_merging_get_next_async_iterator_factory_.md
+++ b/docs/modules/_async_base_merging_get_next_async_iterator_factory_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / "async-base/merging/get-next-async-iterator-factory"
 

--- a/docs/modules/_async_base_merging_index_.md
+++ b/docs/modules/_async_base_merging_index_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / "async-base/merging/index"
 

--- a/docs/modules/_async_base_merging_index_.md
+++ b/docs/modules/_async_base_merging_index_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / "async-base/merging/index"
 

--- a/docs/modules/_async_base_merging_index_.md
+++ b/docs/modules/_async_base_merging_index_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / "async-base/merging/index"
 

--- a/docs/modules/_async_base_merging_merge_iterators_.md
+++ b/docs/modules/_async_base_merging_merge_iterators_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / "async-base/merging/merge-iterators"
 

--- a/docs/modules/_async_base_merging_merge_iterators_.md
+++ b/docs/modules/_async_base_merging_merge_iterators_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / "async-base/merging/merge-iterators"
 

--- a/docs/modules/_async_base_merging_merge_iterators_.md
+++ b/docs/modules/_async_base_merging_merge_iterators_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / "async-base/merging/merge-iterators"
 

--- a/docs/modules/_async_base_merging_merge_types_.md
+++ b/docs/modules/_async_base_merging_merge_types_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / "async-base/merging/merge-types"
 

--- a/docs/modules/_async_base_merging_merge_types_.md
+++ b/docs/modules/_async_base_merging_merge_types_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / "async-base/merging/merge-types"
 

--- a/docs/modules/_async_base_merging_merge_types_.md
+++ b/docs/modules/_async_base_merging_merge_types_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / "async-base/merging/merge-types"
 

--- a/docs/modules/_depaginator_.md
+++ b/docs/modules/_depaginator_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / "depaginator"
 

--- a/docs/modules/_depaginator_.md
+++ b/docs/modules/_depaginator_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / "depaginator"
 

--- a/docs/modules/_depaginator_.md
+++ b/docs/modules/_depaginator_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / "depaginator"
 

--- a/docs/modules/_emitter_base_emitting_conversion_.md
+++ b/docs/modules/_emitter_base_emitting_conversion_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / "emitter/base-emitting-conversion"
 

--- a/docs/modules/_emitter_base_emitting_conversion_.md
+++ b/docs/modules/_emitter_base_emitting_conversion_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / "emitter/base-emitting-conversion"
 

--- a/docs/modules/_emitter_base_emitting_conversion_.md
+++ b/docs/modules/_emitter_base_emitting_conversion_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / "emitter/base-emitting-conversion"
 

--- a/docs/modules/_emitter_combine_emitter_.md
+++ b/docs/modules/_emitter_combine_emitter_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / "emitter/combine-emitter"
 

--- a/docs/modules/_emitter_combine_emitter_.md
+++ b/docs/modules/_emitter_combine_emitter_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / "emitter/combine-emitter"
 

--- a/docs/modules/_emitter_combine_emitter_.md
+++ b/docs/modules/_emitter_combine_emitter_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / "emitter/combine-emitter"
 

--- a/docs/modules/_emitter_concat_emitter_.md
+++ b/docs/modules/_emitter_concat_emitter_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / "emitter/concat-emitter"
 

--- a/docs/modules/_emitter_concat_emitter_.md
+++ b/docs/modules/_emitter_concat_emitter_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / "emitter/concat-emitter"
 

--- a/docs/modules/_emitter_concat_emitter_.md
+++ b/docs/modules/_emitter_concat_emitter_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / "emitter/concat-emitter"
 

--- a/docs/modules/_emitter_get_iterable_from_emitter_.md
+++ b/docs/modules/_emitter_get_iterable_from_emitter_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / "emitter/get-iterable-from-emitter"
 

--- a/docs/modules/_emitter_get_iterable_from_emitter_.md
+++ b/docs/modules/_emitter_get_iterable_from_emitter_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / "emitter/get-iterable-from-emitter"
 

--- a/docs/modules/_emitter_get_iterable_from_emitter_.md
+++ b/docs/modules/_emitter_get_iterable_from_emitter_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / "emitter/get-iterable-from-emitter"
 

--- a/docs/modules/_emitter_index_.md
+++ b/docs/modules/_emitter_index_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / "emitter/index"
 

--- a/docs/modules/_emitter_index_.md
+++ b/docs/modules/_emitter_index_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / "emitter/index"
 

--- a/docs/modules/_emitter_index_.md
+++ b/docs/modules/_emitter_index_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / "emitter/index"
 

--- a/docs/modules/_emitter_merge_emitter_.md
+++ b/docs/modules/_emitter_merge_emitter_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / "emitter/merge-emitter"
 

--- a/docs/modules/_emitter_merge_emitter_.md
+++ b/docs/modules/_emitter_merge_emitter_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / "emitter/merge-emitter"
 

--- a/docs/modules/_emitter_merge_emitter_.md
+++ b/docs/modules/_emitter_merge_emitter_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / "emitter/merge-emitter"
 

--- a/docs/modules/_emitter_merge_emitter_catching_.md
+++ b/docs/modules/_emitter_merge_emitter_catching_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / "emitter/merge-emitter-catching"
 

--- a/docs/modules/_emitter_merge_emitter_catching_.md
+++ b/docs/modules/_emitter_merge_emitter_catching_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / "emitter/merge-emitter-catching"
 

--- a/docs/modules/_emitter_merge_emitter_catching_.md
+++ b/docs/modules/_emitter_merge_emitter_catching_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / "emitter/merge-emitter-catching"
 

--- a/docs/modules/_extend_.md
+++ b/docs/modules/_extend_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / "extend"
 

--- a/docs/modules/_extend_.md
+++ b/docs/modules/_extend_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / "extend"
 

--- a/docs/modules/_extend_.md
+++ b/docs/modules/_extend_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / "extend"
 

--- a/docs/modules/_extend_async_.md
+++ b/docs/modules/_extend_async_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / "extend-async"
 

--- a/docs/modules/_extend_async_.md
+++ b/docs/modules/_extend_async_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / "extend-async"
 

--- a/docs/modules/_extend_async_.md
+++ b/docs/modules/_extend_async_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / "extend-async"
 

--- a/docs/modules/_fluent_.md
+++ b/docs/modules/_fluent_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / "fluent"
 

--- a/docs/modules/_fluent_.md
+++ b/docs/modules/_fluent_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / "fluent"
 

--- a/docs/modules/_fluent_.md
+++ b/docs/modules/_fluent_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / "fluent"
 

--- a/docs/modules/_fluent_async_.md
+++ b/docs/modules/_fluent_async_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / "fluent-async"
 

--- a/docs/modules/_fluent_async_.md
+++ b/docs/modules/_fluent_async_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / "fluent-async"
 

--- a/docs/modules/_fluent_async_.md
+++ b/docs/modules/_fluent_async_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / "fluent-async"
 

--- a/docs/modules/_index_.md
+++ b/docs/modules/_index_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / "index"
 

--- a/docs/modules/_index_.md
+++ b/docs/modules/_index_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / "index"
 

--- a/docs/modules/_index_.md
+++ b/docs/modules/_index_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / "index"
 

--- a/docs/modules/_interval_.md
+++ b/docs/modules/_interval_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / "interval"
 

--- a/docs/modules/_interval_.md
+++ b/docs/modules/_interval_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / "interval"
 

--- a/docs/modules/_interval_.md
+++ b/docs/modules/_interval_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / "interval"
 

--- a/docs/modules/_transform_obj_values_.md
+++ b/docs/modules/_transform_obj_values_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / "transform-obj-values"
 

--- a/docs/modules/_transform_obj_values_.md
+++ b/docs/modules/_transform_obj_values_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / "transform-obj-values"
 

--- a/docs/modules/_transform_obj_values_.md
+++ b/docs/modules/_transform_obj_values_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / "transform-obj-values"
 

--- a/docs/modules/_types_.md
+++ b/docs/modules/_types_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / "types"
 

--- a/docs/modules/_types_.md
+++ b/docs/modules/_types_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / "types"
 

--- a/docs/modules/_types_.md
+++ b/docs/modules/_types_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / "types"
 

--- a/docs/modules/_types_base_.md
+++ b/docs/modules/_types_base_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / "types-base"
 

--- a/docs/modules/_types_base_.md
+++ b/docs/modules/_types_base_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / "types-base"
 

--- a/docs/modules/_types_base_.md
+++ b/docs/modules/_types_base_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / "types-base"
 

--- a/docs/modules/_types_emitter_.md
+++ b/docs/modules/_types_emitter_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / "types-emitter"
 

--- a/docs/modules/_types_emitter_.md
+++ b/docs/modules/_types_emitter_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / "types-emitter"
 

--- a/docs/modules/_types_emitter_.md
+++ b/docs/modules/_types_emitter_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / "types-emitter"
 

--- a/docs/modules/_types_key_._types_.md
+++ b/docs/modules/_types_key_._types_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / ["types-key"](_types_key_.md) / "types"
 

--- a/docs/modules/_types_key_._types_.md
+++ b/docs/modules/_types_key_._types_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / ["types-key"](_types_key_.md) / "types"
 
@@ -15,6 +15,7 @@
 
 * [AsyncItemType](_types_key_._types_.md#asyncitemtype)
 * [ItemType](_types_key_._types_.md#itemtype)
+* [ToObjectKeyType](_types_key_._types_.md#toobjectkeytype)
 
 ## Type aliases
 
@@ -43,3 +44,16 @@ Represents the type of the item of an iterable
 Name |
 ------ |
 `T` |
+
+___
+
+### ToObjectKeyType
+
+Ƭ  **ToObjectKeyType**\<T, R1>: T[R1] *extends* string \| number \| symbol ? T[R1] : any
+
+#### Type parameters:
+
+Name | Type |
+------ | ------ |
+`T` | - |
+`R1` | keyof T |

--- a/docs/modules/_types_key_._types_.md
+++ b/docs/modules/_types_key_._types_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / ["types-key"](_types_key_.md) / "types"
 

--- a/docs/modules/_types_key_.md
+++ b/docs/modules/_types_key_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / "types-key"
 

--- a/docs/modules/_types_key_.md
+++ b/docs/modules/_types_key_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / "types-key"
 

--- a/docs/modules/_types_key_.md
+++ b/docs/modules/_types_key_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / "types-key"
 

--- a/docs/modules/_utils_.md
+++ b/docs/modules/_utils_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.4](../README.md)**
+**[fluent-iterable - v1.7.5](../README.md)**
 
 > [Globals](../README.md) / "utils"
 

--- a/docs/modules/_utils_.md
+++ b/docs/modules/_utils_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.3](../README.md)**
+**[fluent-iterable - v1.7.4](../README.md)**
 
 > [Globals](../README.md) / "utils"
 

--- a/docs/modules/_utils_.md
+++ b/docs/modules/_utils_.md
@@ -1,4 +1,4 @@
-**[fluent-iterable - v1.7.2](../README.md)**
+**[fluent-iterable - v1.7.3](../README.md)**
 
 > [Globals](../README.md) / "utils"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@codibre/fluent-iterable",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@codibre/fluent-iterable",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@codibre/fluent-iterable",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@codibre/fluent-iterable",
   "description": "Provides LINQ-like fluent api operations for iterables and async iterables (ES2018+).",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "private": false,
   "author": {
     "name": "Thiago O Santos <tos.oliveira@gmail.com>"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@codibre/fluent-iterable",
   "description": "Provides LINQ-like fluent api operations for iterables and async iterables (ES2018+).",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "private": false,
   "author": {
     "name": "Thiago O Santos <tos.oliveira@gmail.com>"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@codibre/fluent-iterable",
   "description": "Provides LINQ-like fluent api operations for iterables and async iterables (ES2018+).",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "private": false,
   "author": {
     "name": "Thiago O Santos <tos.oliveira@gmail.com>"

--- a/src/types-key.ts
+++ b/src/types-key.ts
@@ -13,7 +13,12 @@ declare module './types' {
    */
   type AsyncItemType<T> = T extends AnyIterable<infer R> ? R : never;
 
-  type ToObjectKeyType<T, R1 extends keyof T> = (T[R1] extends string | number | symbol ? T[R1] : any);
+  type ToObjectKeyType<T, R1 extends keyof T> = T[R1] extends
+    | string
+    | number
+    | symbol
+    ? T[R1]
+    : any;
 
   /**
    * Represents an iterable extended with common processing and mutating capabilities.<br>
@@ -758,7 +763,7 @@ declare module './types' {
     toObject<R1 extends keyof T, R = T[R1]>(
       keySelector: R1,
       valueSelector?: AsyncMapper<T, R>,
-    ): Promise<{ [key in R1]: R}>;
+    ): Promise<{ [key in R1]: R }>;
 
     /**
      * Translates the iterable into an object using the elements of the iterable as representations of fields as specified by a key- and value selector. This is a resolving operation, will cause a full loop through all the elements of the iterable.
@@ -770,7 +775,7 @@ declare module './types' {
     toObject<K extends string | symbol | number, R2 extends keyof T>(
       keySelector: AsyncMapper<T, K>,
       valueSelector: R2,
-    ): Promise<{ [key in K]: R2}>;
+    ): Promise<{ [key in K]: R2 }>;
 
     /**
      * Translates the iterable into an object using the elements of the iterable as representations of fields as specified by a key- and value selector. This is a resolving operation, will cause a full loop through all the elements of the iterable.
@@ -782,7 +787,7 @@ declare module './types' {
     toObject<R1 extends keyof T, R2 extends keyof T>(
       keySelector: R1,
       valueSelector: R2,
-    ): Promise<{ [key in R1]: R2}>;
+    ): Promise<{ [key in R1]: R2 }>;
 
     /**
      * Iterates through the iterable and executes an action against each element. This is a resolving operation, will cause a full loop through all the elements of the iterable.

--- a/src/types-key.ts
+++ b/src/types-key.ts
@@ -13,6 +13,8 @@ declare module './types' {
    */
   type AsyncItemType<T> = T extends AnyIterable<infer R> ? R : never;
 
+  type ToObjectKeyType<T, R1 extends keyof T> = (T[R1] extends string | number | symbol ? T[R1] : any);
+
   /**
    * Represents an iterable extended with common processing and mutating capabilities.<br>
    *   The capabilities introduced are defined as a [fluent interface](https://en.wikipedia.org/wiki/Fluent_interface) and thus they support *method chaining*.
@@ -347,7 +349,7 @@ declare module './types' {
     toObject<R1 extends keyof T, R = T[R1]>(
       keySelector: R1,
       valueSelector?: Mapper<T, R>,
-    ): any;
+    ): { [key in ToObjectKeyType<T, R1>]: R };
 
     /**
      * Translates the iterable into an object using the elements of the iterable as representations of fields as specified by a key- and value selector. This is a resolving operation, will cause a full loop through all the elements of the iterable.<br>
@@ -359,10 +361,10 @@ declare module './types' {
      * @param valueSelector Projects an element of the iterable into the value of the corresponding field. The identity function is being used if omitted.
      * @returns The object composed of the elements of the iterable as fields.
      */
-    toObject<R2 extends keyof T>(
-      keySelector: Mapper<T, any>,
+    toObject<K extends string | symbol | number, R2 extends keyof T>(
+      keySelector: Mapper<T, K>,
       valueSelector: R2,
-    ): any;
+    ): { [key in K]: T[R2] };
 
     /**
      * Translates the iterable into an object using the elements of the iterable as representations of fields as specified by a key- and value selector. This is a resolving operation, will cause a full loop through all the elements of the iterable.<br>
@@ -377,7 +379,7 @@ declare module './types' {
     toObject<R1 extends keyof T, R2 extends keyof T>(
       keySelector: R1,
       valueSelector: R2,
-    ): any;
+    ): { [key in ToObjectKeyType<T, R1>]: T[R2] };
 
     /**
      * Translates the iterable into an object using the elements of the iterable as representations of fields as specified by an asynchronous key- and value selector. This is a resolving operation, will cause a full loop through all the elements of the iterable.
@@ -389,7 +391,7 @@ declare module './types' {
     toObjectAsync<R1 extends keyof T, R = T[R1]>(
       keySelector: R1,
       valueSelector?: AsyncMapper<T, R>,
-    ): Promise<any>;
+    ): Promise<{ [key in ToObjectKeyType<T, R1>]: R }>;
     /**
      * Translates the iterable into an object using the elements of the iterable as representations of fields as specified by an asynchronous key- and value selector. This is a resolving operation, will cause a full loop through all the elements of the iterable.
      * @typeparam R The expected type of the object. Cannot be enforced, this is strictly informal.
@@ -397,10 +399,10 @@ declare module './types' {
      * @param valueSelector Asynchronously projects an element of the iterable into the value of the corresponding field.
      * @returns A promise of the object composed of the elements of the iterable as fields.
      */
-    toObjectAsync<R2 extends keyof T>(
-      keySelector: AsyncMapper<T, any>,
+    toObjectAsync<K extends string | symbol | number, R2 extends keyof T>(
+      keySelector: AsyncMapper<T, K>,
       valueSelector: R2,
-    ): Promise<any>;
+    ): Promise<{ [key in K]: T[R2] }>;
 
     /**
      * Translates the iterable into an object using the elements of the iterable as representations of fields as specified by an asynchronous key- and value selector. This is a resolving operation, will cause a full loop through all the elements of the iterable.
@@ -412,7 +414,7 @@ declare module './types' {
     toObjectAsync<R1 extends keyof T, R2 extends keyof T>(
       keySelector: R1,
       valueSelector: R2,
-    ): Promise<any>;
+    ): Promise<{ [key in ToObjectKeyType<T, R1>]: T[R2] }>;
 
     /**
      * Projects and concatenates the elements of the iterable into a `string` using a separator. This is a resolving operation, will cause a full loop through all the elements of the iterable.<br>
@@ -739,7 +741,7 @@ declare module './types' {
     toObject<R1 extends keyof T, R = T[R1]>(
       keySelector: R1,
       valueSelector?: AsyncMapper<T, R>,
-    ): Promise<any>;
+    ): Promise<{ [key in R1]: R}>;
 
     /**
      * Translates the iterable into an object using the elements of the iterable as representations of fields as specified by a key- and value selector. This is a resolving operation, will cause a full loop through all the elements of the iterable.
@@ -748,10 +750,10 @@ declare module './types' {
      * @param valueSelector Projects an element of the iterable into the value of the corresponding field. The identity function is being used if omitted.
      * @returns A promise of the object composed of the elements of the iterable as fields.
      */
-    toObject<R2 extends keyof T>(
-      keySelector: AsyncMapper<T, any>,
+    toObject<K extends string | symbol | number, R2 extends keyof T>(
+      keySelector: AsyncMapper<T, K>,
       valueSelector: R2,
-    ): Promise<any>;
+    ): Promise<{ [key in K]: R2}>;
 
     /**
      * Translates the iterable into an object using the elements of the iterable as representations of fields as specified by a key- and value selector. This is a resolving operation, will cause a full loop through all the elements of the iterable.
@@ -763,7 +765,7 @@ declare module './types' {
     toObject<R1 extends keyof T, R2 extends keyof T>(
       keySelector: R1,
       valueSelector: R2,
-    ): Promise<any>;
+    ): Promise<{ [key in R1]: R2}>;
 
     /**
      * Iterates through the iterable and executes an action against each element. This is a resolving operation, will cause a full loop through all the elements of the iterable.


### PR DESCRIPTION
The type returned by toObject when using key strings could be more precisely than just "any" if we use conditional typing.

This PRs take that approach, which can remove the need to create custom interfaces on the package users in many cases