### PR TITLE
Bettering filter signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 
-## 1.9.2
+## 1.10.0
+* 264233a 1.10.0
+* bdf61e5 creating implicity identity filter
+* 52d9512 bettering filter signature
+* cb0d4a5 Iterable obj entries type (#37)
 ## v1.9.2
 * 756f909 1.9.2
 * 67b3749 fixing iterateObjEntries return type
@@ -157,6 +161,88 @@
 * 4c95d7a updating package lock"
 * d7f049a updating packages
 ## v1.2.0
+## v1.10.0
+* 264233a 1.10.0
+* bdf61e5 creating implicity identity filter
+* 52d9512 bettering filter signature
+* cb0d4a5 Iterable obj entries type (#37)
+* 8722ee3 Fixing group type (#36)
+* 8173e93 Es compliance (#35)
+* 140573b Refactoring partition, yields and types (#34)
+* bb5b13c Augmentative iterable update (#33)
+* 61822ee Return self when fluent (#32)
+* 79f70b2 Fixing to object return type with key (#30)
+* ec2c2ea bug with typing when flatten with no parameter (#29)
+* e7a095a Issue 26 bug with typing when flatten uses string field property (#28)
+* 2dde58d Release (#24)
+* 82f25ea Release (#23)
+* 2a64d19 fixing sum (#21)
+* 2f8fbb4 creating sortBy method (#22)
+* 00ced81 fixing import name lib in readme file (#19)
+* 95af91f creating publish action (#17)
+* 63ed241 1.6.0 (#16)
+* 760da33 Issue 14 make fluent accept strings in place of functions (#15)
+* 712fa57 Issue 11 order assuring option for faster opertations (#12)
+* 4060526 Issue 9 implement method is dinstinct (#10)
+* c75cd5d adding emit methods (#8)
+* 0fe6265 expanding min and max contracts to accepts non numeric values (#6)
+* e1ff83d 1.5.0
+* 0518e30 Merge branch 'master' of github.com:Codibre/fluent-iterable
+* a695499 separating average from iterative means calculation for a more utils exporting
+* fc04398 Update README.md
+* 1102727 1.4.0
+* 7db5dc2 Merge pull request #4 from Codibre/issue-1-Implementing_fluentEvent
+* 6511552 updating for-emit-of
+* 37da974 ending events cache
+* d26e007 adding custom treatment for break using in the for await
+* 1200ab0 sync with master
+* 93b85b2 Merge branch 'master' of github.com:Codibre/fluent-iterable into issue-1-Implementing_fluentEvent
+* ea61ebe 1.3.4
+* e387454 adding return call for cases where next is used
+* 3ba3c6d 1.3.3
+* 63199c8 updating augmentative iterable for Iterator.return properly call support
+* 1d672b3 updating forEmitOf library
+* 8b0b9f2 Merge branch 'master' of github.com:Codibre/fluent-iterable into issue-1-Implementing_fluentEvent
+* 8e08d88 Merge branch 'master' of github.com:Codibre/fluent-iterable
+* d63301b 1.3.2
+* 06588d6 Update README.md
+* 2d9f968 updating codeclimate after repo remaking
+* 6bf1722 just a change to make codeclimate update numbers
+* 8fef128 Adding workflow
+* 00bba4c Removing workflow
+* 6915268 updating libraries and centralizing forEmitOf using
+* b473d47 adding tsdoc information about EventEmitter Iterables
+* 265bf66 fixing forEmitOf importing
+* 81b567e changing test setup as promise handling works slightly different since node 12.x in the matter of setImmediate functionality (it's too imediately for our test)
+* e40922d fixing duplicated code
+* dbd5e17 fixing types size
+* e51cc6e implementing fluentEmit and EventEmitter operators
+* f55529f Merge branch 'master' of github.com:Codibre/fluent-iterable
+* 931880b 1.3.1
+* bca0c2b Using iterative mean algorithm http://www.heikohoffmann.de/htmlthesis/node134.html to calculate avg
+* 580969e Update README.md
+* a961e58 updating readme"
+* b8b8fe1 updating readme
+* c00ff3d adding faulting case tests
+* 2b8a126 refactoring combine
+* e1622b3 refactoring combine
+* 1a67cd0 adding one more test case
+* 2596ded 1.3.0
+* f889db1 creating key combiner
+* a6e5243 1.2.5
+* 680df96 updating to stable version of dependencies
+* 526cd40 1.2.4
+* c032cc6 updating version of augmentative for the one with strict mode
+* f78c49a Adding memory test or native approach
+* fe96d52 1.2.3
+* d149a28 fixing lint
+* f6e6bba updating changelog and docs
+* 8505952 updating version
+* 72cde26 updating version
+* 29c5b69 adding memory test and fluent interface for interval
+* a3821ba 1.2.1
+* 4c95d7a updating package lock"
+* d7f049a updating packages
 * 0db8262 1.2.0
 * 05c5953 completing coverage and adding more methods
 * 2d52b34 calibrating performing test

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-fluent-iterable - v1.9.2
+fluent-iterable - v1.10.0
 
-# fluent-iterable - v1.9.2
+# fluent-iterable - v1.10.0
 
 ## Table of contents
 

--- a/docs/interfaces/action.md
+++ b/docs/interfaces/action.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v1.9.2](../README.md) / Action
+[fluent-iterable - v1.10.0](../README.md) / Action
 
 # Interface: Action<T\>
 

--- a/docs/interfaces/asyncaction.md
+++ b/docs/interfaces/asyncaction.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v1.9.2](../README.md) / AsyncAction
+[fluent-iterable - v1.10.0](../README.md) / AsyncAction
 
 # Interface: AsyncAction<T\>
 

--- a/docs/interfaces/asyncmapper.md
+++ b/docs/interfaces/asyncmapper.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v1.9.2](../README.md) / AsyncMapper
+[fluent-iterable - v1.10.0](../README.md) / AsyncMapper
 
 # Interface: AsyncMapper<T, R\>
 

--- a/docs/interfaces/asyncreducer.md
+++ b/docs/interfaces/asyncreducer.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v1.9.2](../README.md) / AsyncReducer
+[fluent-iterable - v1.10.0](../README.md) / AsyncReducer
 
 # Interface: AsyncReducer<T, A\>
 

--- a/docs/interfaces/comparer.md
+++ b/docs/interfaces/comparer.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v1.9.2](../README.md) / Comparer
+[fluent-iterable - v1.10.0](../README.md) / Comparer
 
 # Interface: Comparer<T\>
 

--- a/docs/interfaces/fluentasynciterable.md
+++ b/docs/interfaces/fluentasynciterable.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v1.9.2](../README.md) / FluentAsyncIterable
+[fluent-iterable - v1.10.0](../README.md) / FluentAsyncIterable
 
 # Interface: FluentAsyncIterable<T\>
 

--- a/docs/interfaces/fluentemitter.md
+++ b/docs/interfaces/fluentemitter.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v1.9.2](../README.md) / FluentEmitter
+[fluent-iterable - v1.10.0](../README.md) / FluentEmitter
 
 # Interface: FluentEmitter<T\>
 

--- a/docs/interfaces/fluentgroup.md
+++ b/docs/interfaces/fluentgroup.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v1.9.2](../README.md) / FluentGroup
+[fluent-iterable - v1.10.0](../README.md) / FluentGroup
 
 # Interface: FluentGroup<T, R\>
 

--- a/docs/interfaces/fluentiterable.md
+++ b/docs/interfaces/fluentiterable.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v1.9.2](../README.md) / FluentIterable
+[fluent-iterable - v1.10.0](../README.md) / FluentIterable
 
 # Interface: FluentIterable<T\>
 

--- a/docs/interfaces/group.md
+++ b/docs/interfaces/group.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v1.9.2](../README.md) / Group
+[fluent-iterable - v1.10.0](../README.md) / Group
 
 # Interface: Group<T, R\>
 

--- a/docs/interfaces/mapper.md
+++ b/docs/interfaces/mapper.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v1.9.2](../README.md) / Mapper
+[fluent-iterable - v1.10.0](../README.md) / Mapper
 
 # Interface: Mapper<T, R\>
 

--- a/docs/interfaces/orderassurable.md
+++ b/docs/interfaces/orderassurable.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v1.9.2](../README.md) / OrderAssurable
+[fluent-iterable - v1.10.0](../README.md) / OrderAssurable
 
 # Interface: OrderAssurable<T\>
 

--- a/docs/interfaces/page.md
+++ b/docs/interfaces/page.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v1.9.2](../README.md) / Page
+[fluent-iterable - v1.10.0](../README.md) / Page
 
 # Interface: Page<T, TToken\>
 

--- a/docs/interfaces/pager.md
+++ b/docs/interfaces/pager.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v1.9.2](../README.md) / Pager
+[fluent-iterable - v1.10.0](../README.md) / Pager
 
 # Interface: Pager<T, TToken\>
 

--- a/docs/interfaces/reducer.md
+++ b/docs/interfaces/reducer.md
@@ -1,4 +1,4 @@
-[fluent-iterable - v1.9.2](../README.md) / Reducer
+[fluent-iterable - v1.10.0](../README.md) / Reducer
 
 # Interface: Reducer<T, A\>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@codibre/fluent-iterable",
-  "version": "1.9.2",
+  "version": "1.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@codibre/fluent-iterable",
-      "version": "1.9.2",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
         "augmentative-iterable": "^1.1.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@codibre/fluent-iterable",
   "description": "Provides LINQ-like fluent api operations for iterables and async iterables (ES2018+).",
-  "version": "1.9.2",
+  "version": "1.10.0",
   "private": false,
   "author": {
     "name": "Thiago O Santos <tos.oliveira@gmail.com>"

--- a/src/recipes/filter-recipe.ts
+++ b/src/recipes/filter-recipe.ts
@@ -6,6 +6,7 @@ import {
   ResolverType,
 } from '../types-internal';
 import { prepare } from '../types-internal/prepare';
+import { identity } from '../utils';
 import { augmentIterableRecipe } from './augment-iterable-recipe';
 
 export function filterRecipe(
@@ -16,7 +17,10 @@ export function filterRecipe(
   const baseFilter = augmentIterableRecipe(filterIterable);
   const takeWhile = augmentIterableRecipe(takeWhileIterable);
 
-  return function <T>(this: AnyIterable<T>, basePredicate: AnyMapper<any>) {
+  return function <T>(
+    this: AnyIterable<T>,
+    basePredicate: AnyMapper<any> = identity,
+  ) {
     const predicate = prepare(basePredicate);
     if (isAnyOrderAssured(predicate, this)) {
       let alreadyTrue = false;

--- a/src/types/function-types/filter-function.ts
+++ b/src/types/function-types/filter-function.ts
@@ -6,9 +6,10 @@ type Truthy<T> = Exclude<
   undefined
 >;
 
-type RequiresTruthy<T, Guarantees extends keyof T> = {
-  [P in Guarantees]-?: Truthy<T[P]>;
-};
+type RequiresTruthy<T, Guarantees extends keyof T> = T &
+  {
+    [P in Guarantees]-?: Truthy<T[P]>;
+  };
 
 export interface FilterFunction<T> {
   /**
@@ -24,7 +25,7 @@ export interface FilterFunction<T> {
    * @returns A [[FluentIterable]] of the elements against which the predicate evaluates to `true`.
    */
   <Guarantees extends keyof T = any>(predicate: Predicate<T>): FluentIterable<
-    T & RequiresTruthy<T, Guarantees>
+    RequiresTruthy<T, Guarantees>
   >;
   /**
    * Filters the iterable of `T` based on a predicate.<br>
@@ -32,7 +33,7 @@ export interface FilterFunction<T> {
    * @param predicate A predicate of `T`. All elements are yielded from the iterable against which this evaluates to `true`.
    * @returns A [[FluentIterable]] of the elements against which the predicate evaluates to `true`.
    */
-  <K extends keyof T>(predicate: K): FluentIterable<T & RequiresTruthy<T, K>>;
+  <K extends keyof T>(predicate: K): FluentIterable<RequiresTruthy<T, K>>;
 }
 export interface AsyncFilterFunction<T> {
   /**
@@ -48,13 +49,13 @@ export interface AsyncFilterFunction<T> {
    */
   <Guarantees extends keyof T = any>(
     predicate: AsyncPredicate<T>,
-  ): FluentAsyncIterable<T & RequiresTruthy<T, Guarantees>>;
+  ): FluentAsyncIterable<RequiresTruthy<T, Guarantees>>;
   /**
    * Filters the iterable of `T` based on an asynchronous predicate.
    * @param predicate An asynchronous predicate of `T`. All elements are yielded from the iterable against which this evaluates to `true`.
    * @returns A [[FluentAsyncIterable]] of the elements against which the predicate evaluates to `true`.
    */
   <R extends keyof T, K extends keyof T>(predicate: R): FluentAsyncIterable<
-    T & RequiresTruthy<T, K>
+    RequiresTruthy<T, K>
   >;
 }

--- a/src/types/function-types/filter-function.ts
+++ b/src/types/function-types/filter-function.ts
@@ -12,6 +12,12 @@ type RequiresTruthy<T, Guarantees extends keyof T> = {
 
 export interface FilterFunction<T> {
   /**
+   * Filters the falsy values of a iterable of `T`<br>
+   *   Example: `fluent(['anchor', undefined, 'bound', undefined]).filter()` yields *anchor* and *bound*.
+   * @returns A [[FluentIterable]] of the elements against which the predicate evaluates to `true`.
+   */
+  (): FluentIterable<Truthy<T>>;
+  /**
    * Filters the iterable of `T` based on a predicate.<br>
    *   Example: `fluent(['anchor', 'almond', 'bound', 'alpine']).filter(word => word[0] === 'a')` yields *anchor*, *almond*, and *alpine*.
    * @param predicate A predicate of `T`. All elements are yielded from the iterable against which this evaluates to `true`.
@@ -29,6 +35,12 @@ export interface FilterFunction<T> {
   <K extends keyof T>(predicate: K): FluentIterable<T & RequiresTruthy<T, K>>;
 }
 export interface AsyncFilterFunction<T> {
+  /**
+   * Filters the falsy values of a iterable of `T`<br>
+   *   Example: `fluentAsync(['anchor', undefined, 'bound', undefined]).filter()` yields *anchor* and *bound*.
+   * @returns A [[FluentAsyncIterable]] of the elements against which the predicate evaluates to `true`.
+   */
+  (): FluentAsyncIterable<Truthy<T>>;
   /**
    * Filters the iterable of `T` based on an asynchronous predicate.
    * @param predicate An asynchronous predicate of `T`. All elements are yielded from the iterable against which this evaluates to `true`.

--- a/src/types/function-types/filter-function.ts
+++ b/src/types/function-types/filter-function.ts
@@ -1,6 +1,15 @@
 import { AsyncPredicate, Predicate } from 'augmentative-iterable';
 import { FluentAsyncIterable, FluentIterable } from '../base';
 
+type Truthy<T> = Exclude<
+  Exclude<Exclude<Exclude<Exclude<T, false>, 0>, ''>, null>,
+  undefined
+>;
+
+type RequiresTruthy<T, Guarantees extends keyof T> = {
+  [P in Guarantees]-?: Truthy<T[P]>;
+};
+
 export interface FilterFunction<T> {
   /**
    * Filters the iterable of `T` based on a predicate.<br>
@@ -8,14 +17,16 @@ export interface FilterFunction<T> {
    * @param predicate A predicate of `T`. All elements are yielded from the iterable against which this evaluates to `true`.
    * @returns A [[FluentIterable]] of the elements against which the predicate evaluates to `true`.
    */
-  (predicate: Predicate<T>): FluentIterable<T>;
+  <Guarantees extends keyof T = any>(predicate: Predicate<T>): FluentIterable<
+    T & RequiresTruthy<T, Guarantees>
+  >;
   /**
    * Filters the iterable of `T` based on a predicate.<br>
    *   Example: `fluent(['anchor', 'almond', 'bound', 'alpine']).filter(word => word[0] === 'a')` yields *anchor*, *almond*, and *alpine*.
    * @param predicate A predicate of `T`. All elements are yielded from the iterable against which this evaluates to `true`.
    * @returns A [[FluentIterable]] of the elements against which the predicate evaluates to `true`.
    */
-  (predicate: keyof T): FluentIterable<T>;
+  <K extends keyof T>(predicate: K): FluentIterable<T & RequiresTruthy<T, K>>;
 }
 export interface AsyncFilterFunction<T> {
   /**
@@ -23,11 +34,15 @@ export interface AsyncFilterFunction<T> {
    * @param predicate An asynchronous predicate of `T`. All elements are yielded from the iterable against which this evaluates to `true`.
    * @returns A [[FluentAsyncIterable]] of the elements against which the predicate evaluates to `true`.
    */
-  (predicate: AsyncPredicate<T>): FluentAsyncIterable<T>;
+  <Guarantees extends keyof T = any>(
+    predicate: AsyncPredicate<T>,
+  ): FluentAsyncIterable<T & RequiresTruthy<T, Guarantees>>;
   /**
    * Filters the iterable of `T` based on an asynchronous predicate.
    * @param predicate An asynchronous predicate of `T`. All elements are yielded from the iterable against which this evaluates to `true`.
    * @returns A [[FluentAsyncIterable]] of the elements against which the predicate evaluates to `true`.
    */
-  <R extends keyof T>(predicate: R): FluentAsyncIterable<T>;
+  <R extends keyof T, K extends keyof T>(predicate: R): FluentAsyncIterable<
+    T & RequiresTruthy<T, K>
+  >;
 }

--- a/test/fluent.spec.ts
+++ b/test/fluent.spec.ts
@@ -444,6 +444,31 @@ describe('fluent iterable', () => {
               .toArray(),
           ).to.eql([2, 4]);
         });
+        it('should guarantees that a possible falsy unique key is defined', () => {
+          interface Test {
+            a?: number;
+            b: string | null;
+          }
+          expect(
+            fluent([{ b: null, a: 1 }, { b: 'a' }, { a: 2, b: 'b' }] as Test[])
+              .filter('b')
+              .filter('a')
+              .map((x) => `${x.a.toFixed(2)} and ${x.b.length}`)
+              .first(),
+          ).to.be.eq('2.00 and 1');
+        });
+        it('should guarantees that a possible falsy unique key is defined explicitly', () => {
+          interface Test {
+            a?: number;
+            b: string | null;
+          }
+          expect(
+            fluent([{ b: null, a: 1 }, { b: 'a' }, { a: 2, b: 'b' }] as Test[])
+              .filter<'b' | 'a'>((x) => x.b && x.a)
+              .map((x) => `${x.a.toFixed(2)} and ${x.b.length}`)
+              .first(),
+          ).to.be.eq('2.00 and 1');
+        });
       });
       describe('filterAsync', () => {
         it('with always false predicate', async () =>
@@ -476,6 +501,39 @@ describe('fluent iterable', () => {
               .map('b')
               .toArray(),
           ).to.eql([2, 4]);
+        });
+        it('should guarantees that a possible falsy unique key is defined', async () => {
+          interface Test {
+            a?: number;
+            b: string | null;
+          }
+          expect(
+            await fluent([
+              { b: null, a: 1 },
+              { b: 'a' },
+              { a: 2, b: 'b' },
+            ] as Test[])
+              .filterAsync('b')
+              .filter('a')
+              .map((x) => `${x.a.toFixed(2)} and ${x.b.length}`)
+              .first(),
+          ).to.be.eq('2.00 and 1');
+        });
+        it('should guarantees that a possible falsy unique key is defined explicitly', async () => {
+          interface Test {
+            a?: number;
+            b: string | null;
+          }
+          expect(
+            await fluent([
+              { b: null, a: 1 },
+              { b: 'a' },
+              { a: 2, b: 'b' },
+            ] as Test[])
+              .filterAsync<'b' | 'a'>((x) => x.b && x.a)
+              .map((x) => `${x.a.toFixed(2)} and ${x.b.length}`)
+              .first(),
+          ).to.be.eq('2.00 and 1');
         });
       });
       describe('partition', () => {

--- a/test/fluent.spec.ts
+++ b/test/fluent.spec.ts
@@ -469,6 +469,21 @@ describe('fluent iterable', () => {
               .first(),
           ).to.be.eq('2.00 and 1');
         });
+        it('should return just the truthy values with correct typing', () => {
+          interface Test {
+            a: number;
+            b: string;
+          }
+          expect(
+            fluent([{ b: 'abc', a: 1 }, undefined, { a: 2, b: 'b' }] as (
+              | Test
+              | undefined
+            )[])
+              .filter()
+              .map((x) => `${x.a.toFixed(2)} and ${x.b.length}`)
+              .toArray(),
+          ).to.be.eql(['1.00 and 3', '2.00 and 1']);
+        });
       });
       describe('filterAsync', () => {
         it('with always false predicate', async () =>
@@ -534,6 +549,21 @@ describe('fluent iterable', () => {
               .map((x) => `${x.a.toFixed(2)} and ${x.b.length}`)
               .first(),
           ).to.be.eq('2.00 and 1');
+        });
+        it('should return just the truthy values with correct typing', async () => {
+          interface Test {
+            a: number;
+            b: string;
+          }
+          expect(
+            await fluent([{ b: 'abc', a: 1 }, undefined, { a: 2, b: 'b' }] as (
+              | Test
+              | undefined
+            )[])
+              .filterAsync()
+              .map((x) => `${x.a.toFixed(2)} and ${x.b.length}`)
+              .toArray(),
+          ).to.be.eql(['1.00 and 3', '2.00 and 1']);
         });
       });
       describe('partition', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "target": "es2018",
     "rootDir": "./src",
     "outDir": "./dist",
-    "declaration": true
+    "declaration": true,
+    "strictBindCallApply": true
   },
   "include": ["./src"]
 }


### PR DESCRIPTION
* filter with no parameters will apply the identity filter and will make ts identify an Iterable with possible falsy items as an Iterable with guaranteed truthy items;
* filter with property key will make ts identify the k field as a guaranteed truthy field
* filter with function mappers have the option to pass a generic parameter an union of keyof T to inform ts of what fields will be guaranteed to be truth after that filter