### PR TITLE
feat: adding toJSON to make fluent iterables serializable

### DIFF
--- a/src/mounters/fluent-functions.ts
+++ b/src/mounters/fluent-functions.ts
@@ -164,6 +164,7 @@ export const resolvingFuncs = {
   someAsync: anyAsync,
   contains,
   toArray,
+  toJSON: toArray,
   toObject,
   toObjectAsync,
   forEach,

--- a/test/fluent.spec.ts
+++ b/test/fluent.spec.ts
@@ -117,7 +117,9 @@ describe('fluent iterable', () => {
           expect(sum).to.be.eq(6);
         });
         it('should serialize as an array', () => {
-          expect(JSON.stringify(fluent([1, 2, 3]).map((x) => x * 2))).to.be.eql('[2,4,6]');
+          expect(JSON.stringify(fluent([1, 2, 3]).map((x) => x * 2))).to.be.eql(
+            '[2,4,6]',
+          );
         });
       });
       context('withIndex', () => {

--- a/test/fluent.spec.ts
+++ b/test/fluent.spec.ts
@@ -116,6 +116,9 @@ describe('fluent iterable', () => {
           fluent([1, 2, 3]).forEach((x) => (sum += x));
           expect(sum).to.be.eq(6);
         });
+        it('should serialize as an array', () => {
+          expect(JSON.stringify(fluent([1, 2, 3]).map((x) => x * 2))).to.be.eql('[2,4,6]');
+        });
       });
       context('withIndex', () => {
         it('should return Indexed instances from informed array', () => {


### PR DESCRIPTION
Just a simple hack that will make fluent iterable serializable.

That means if you pass a fluent iterable to a JSON.stringify call, it'll be serialized outputting an array string