### PR TITLE
feat: adding toObjectChain

### DIFF
--- a/src/async/index.ts
+++ b/src/async/index.ts
@@ -43,6 +43,7 @@ export * from './take-while-async';
 export * from './to-array-async';
 export * from './to-map-async';
 export * from './to-object-async';
+export * from './to-object-chain-async';
 export * from './to-set-async';
 export * from './top-async';
 export * from './wait-all-async';

--- a/src/async/to-object-chain-async.ts
+++ b/src/async/to-object-chain-async.ts
@@ -1,0 +1,12 @@
+import { toObjectChainRecipe } from '../recipes';
+import { basicAsync } from './basic-ingredients-async';
+import { flatJoinAsync } from './flat-join-async';
+import { groupAsync } from './group-async';
+import { toObjectAsync } from './to-object-async';
+
+export const toObjectChainAsync = toObjectChainRecipe({
+  ...basicAsync,
+  flatJoin: flatJoinAsync,
+  group: groupAsync,
+  toObject: toObjectAsync,
+});

--- a/src/mounters/fluent-async-functions.ts
+++ b/src/mounters/fluent-async-functions.ts
@@ -49,6 +49,7 @@ import {
   toMapAsync,
   toSetAsync,
   flatJoinAsync,
+  toObjectChainAsync,
 } from '../async';
 import {
   combineEmitter,
@@ -122,6 +123,7 @@ export const asyncResolvingFuncs = {
   emit: emitAsync,
   toArray: toArrayAsync,
   toObject: toObjectAsync,
+  toObjectChain: toObjectChainAsync,
   forEach: forEachAsync,
   join: joinAsync,
   sum: sumAsync,

--- a/src/mounters/fluent-functions.ts
+++ b/src/mounters/fluent-functions.ts
@@ -52,6 +52,7 @@ import {
   catchSync,
   next,
   toSet,
+  toObjectChain,
 } from '../sync';
 import {
   allAsync,
@@ -84,6 +85,7 @@ import {
   toMapAsync,
   toSetAsync,
   flatJoinAsync,
+  toObjectChainAsync,
 } from '../async';
 import { combineEmitter, concatEmitter } from '../emitter';
 import * as common from '../common';
@@ -167,6 +169,8 @@ export const resolvingFuncs = {
   toJSON: toArray,
   toObject,
   toObjectAsync,
+  toObjectChain,
+  toObjectChainAsync,
   forEach,
   forEachAsync,
   join,

--- a/src/recipes/index.ts
+++ b/src/recipes/index.ts
@@ -30,6 +30,7 @@ export * from './sum-recipe';
 export * from './take-recipe';
 export * from './take-while-recipe';
 export * from './to-map-recipe';
+export * from './to-object-chain-recipe';
 export * from './to-object-recipe';
 export * from './to-set-recipe';
 export * from './top-recipe';

--- a/src/recipes/ingredients.ts
+++ b/src/recipes/ingredients.ts
@@ -76,3 +76,9 @@ export interface ComparisonIngredients extends BasicIngredients {
   take: ThresholdIngredient;
   comparer: CompareProvider;
 }
+
+export interface ToObjectChainRecipe extends BasicIngredients {
+  flatJoin: Function;
+  group: Function;
+  toObject: Function;
+}

--- a/src/recipes/to-object-chain-recipe.ts
+++ b/src/recipes/to-object-chain-recipe.ts
@@ -1,0 +1,36 @@
+import { AnyIterable } from 'augmentative-iterable';
+import { ToObjectChainRecipe } from './ingredients';
+import { head, tail } from '../types';
+
+function toObjectNode(
+  it: AnyIterable<any>,
+  keys: string[],
+  index: number,
+  ing: ToObjectChainRecipe,
+): any {
+  const key = keys[index];
+  it = ing.flatJoin.call(it, key);
+  it = ing.group.call(it, (x: any) => x[head]);
+  return ing.toObject.call(
+    it,
+    'key',
+    index < keys.length - 1
+      ? (subIt: any) =>
+          toObjectNode(
+            ing.map.call(subIt.values, (x: any) => x[tail]),
+            keys,
+            index + 1,
+            ing,
+          )
+      : (subIt: any) =>
+          ing.toArray.call(ing.map.call(subIt.values, (x: any) => x[tail])),
+  );
+}
+
+export function toObjectChainRecipe(ing: ToObjectChainRecipe) {
+  return function (this: AnyIterable<any>, ...keys: string[]) {
+    return keys.length === 0
+      ? ing.toArray.call(this)
+      : toObjectNode(this, keys, 0, ing);
+  };
+}

--- a/src/sync/index.ts
+++ b/src/sync/index.ts
@@ -45,6 +45,7 @@ export * from './to-array';
 export * from './to-async';
 export * from './to-map';
 export * from './to-object';
+export * from './to-object-chain';
 export * from './to-set';
 export * from './top';
 export * from './wait-all';

--- a/src/sync/to-object-chain.ts
+++ b/src/sync/to-object-chain.ts
@@ -1,0 +1,12 @@
+import { toObjectChainRecipe } from '../recipes';
+import { basic } from './basic-ingredients';
+import { flatJoin } from './flat-join';
+import { group } from './group';
+import { toObject } from './to-object';
+
+export const toObjectChain = toObjectChainRecipe({
+  ...basic,
+  flatJoin,
+  group,
+  toObject,
+});

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -301,3 +301,7 @@ export interface FluentAsyncIterable<T>
   extends AsyncIterable<T>,
     OrderAssurable<FluentAsyncIterable<T>>,
     FluentIterableEmitter<T> {}
+
+export type KeysOfType<T, V> = {
+  [K in keyof T]-?: T[K] extends V ? K : never;
+}[keyof T];

--- a/src/types/fluent-async-iterable.ts
+++ b/src/types/fluent-async-iterable.ts
@@ -35,6 +35,7 @@ declare module './base' {
     toArray: f.AsyncToArrayFunction<T>;
     toMap: f.AsyncToMapFunction<T>;
     toObject: f.AsyncToObjectFunction<T>;
+    toObjectChain: f.AsyncToObjectChainFunction<T>;
     toSet: f.AsyncToSetFunction<T>;
     forEach: f.AsyncForEachFunction<T>;
     execute: f.AsyncExecuteFunction<T>;

--- a/src/types/fluent-iterable.ts
+++ b/src/types/fluent-iterable.ts
@@ -57,6 +57,8 @@ declare module './base' {
     toMapAsync: f.AsyncToMapFunction<T>;
     toObject: f.ToObjectFunction<T>;
     toObjectAsync: f.AsyncToObjectFunction<T>;
+    toObjectChain: f.ToObjectChainFunction<T>;
+    toObjectChainAsync: f.AsyncToObjectChainFunction<T>;
     toSet: f.ToSetFunction<T>;
     toSetAsync: f.AsyncToSetFunction<T>;
     toAsync: f.ToAsyncFunction<T>;

--- a/src/types/function-types/index.ts
+++ b/src/types/function-types/index.ts
@@ -49,6 +49,7 @@ export * from './take-while-function';
 export * from './to-array-function';
 export * from './to-async-function';
 export * from './to-map-function';
+export * from './to-object-chain-function';
 export * from './to-object-function';
 export * from './to-set-function';
 export * from './top-function';

--- a/src/types/function-types/to-object-chain-function.ts
+++ b/src/types/function-types/to-object-chain-function.ts
@@ -1,0 +1,66 @@
+/* eslint-disable no-magic-numbers */
+import { ItemType, KeysOfType } from '../base';
+
+export type ChainKeyType =
+  | string
+  | symbol
+  | number
+  | Array<string | symbol | number>;
+type Indexes = [
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7,
+  8,
+  9,
+  10,
+  11,
+  12,
+  13,
+  14,
+  15,
+  16,
+  17,
+  18,
+  19,
+  20,
+  -1,
+];
+
+export type RecordChain<
+  Arr extends Array<KeysOfType<V, ChainKeyType>>,
+  V,
+  Pos extends number = 0,
+> = {
+  done: V[];
+  any: any;
+  recur: V[Arr[Pos]] extends string | number | symbol
+    ? Record<V[Arr[Pos]], RecordChain<Arr, V, Indexes[Pos]>>
+    : V[Arr[Pos]] extends Array<string | number | symbol>
+    ? Record<ItemType<V[Arr[Pos]]>, RecordChain<Arr, V, Indexes[Pos]>>
+    : never;
+}[Pos extends Arr['length'] ? 'done' : Pos extends -1 ? 'any' : 'recur'];
+
+export interface ToObjectChainFunction<T> {
+  /**
+   * Creates an object chain with the values of the specified fields where the latest
+   * value in the chain will be the iterable item itself. This is a resolving operation
+   * @param keys The keys to be chained
+   * @returns The object chain
+   */
+  <A extends Array<KeysOfType<T, ChainKeyType>>>(...keys: A): RecordChain<A, T>;
+}
+export interface AsyncToObjectChainFunction<T> {
+  /**
+   * Creates an object chain with the values of the specified fields where the latest
+   * value in the chain will be the iterable item itself. This is a resolving operation
+   * @param keys The keys to be chained
+   * @returns The object chain
+   */
+  <A extends Array<KeysOfType<T, ChainKeyType>>>(...keys: A): Promise<
+    RecordChain<A, T>
+  >;
+}

--- a/test/to-object-chain.spec.ts
+++ b/test/to-object-chain.spec.ts
@@ -1,0 +1,186 @@
+import { expect } from 'chai';
+import { fluent, fluentAsync } from '../src';
+
+describe('toObjectChain', () => {
+  describe('iterable', () => {
+    describe('sync', () => {
+      it('should create a object chain based on keyable informed properties', () => {
+        const payload = [
+          {
+            test: ['a', 'b', 'c'],
+            c: 1,
+            d: false,
+            id: 1,
+          },
+          {
+            test: ['b', 'c'],
+            c: 2,
+            d: true,
+            id: 2,
+          },
+          {
+            test: ['c', 'd'],
+            c: 2,
+            d: true,
+            id: 3,
+          },
+        ];
+
+        const result = fluent(payload).toObjectChain('test', 'c');
+
+        expect(result['a'][1].map((x) => x.id)).to.be.eql([1]);
+        expect(result['b'][1].map((x) => x.id)).to.be.eql([1]);
+        expect(result['b'][2].map((x) => x.id)).to.be.eql([2]);
+        expect(result['c'][2].map((x) => x.id)).to.be.eql([2, 3]);
+        expect(result['d'][2].map((x) => x.id)).to.be.eql([3]);
+      });
+
+      it('should return an array when no properties are informed', () => {
+        const payload = [
+          {
+            test: ['a', 'b', 'c'],
+            c: 1,
+            d: false,
+            id: 1,
+          },
+          {
+            test: ['b', 'c'],
+            c: 2,
+            d: true,
+            id: 2,
+          },
+          {
+            test: ['c', 'd'],
+            c: 2,
+            d: true,
+            id: 3,
+          },
+        ];
+
+        const result = fluent(payload).toObjectChain();
+
+        expect(result).to.be.eql(payload);
+      });
+    });
+    describe('async', () => {
+      it('should create a object chain based on keyable informed properties', async () => {
+        const payload = [
+          {
+            test: ['a', 'b', 'c'],
+            c: 1,
+            d: false,
+            id: 1,
+          },
+          {
+            test: ['b', 'c'],
+            c: 2,
+            d: true,
+            id: 2,
+          },
+          {
+            test: ['c', 'd'],
+            c: 2,
+            d: true,
+            id: 3,
+          },
+        ];
+
+        const result = await fluent(payload).toObjectChainAsync('test', 'c');
+
+        expect(result['a'][1].map((x) => x.id)).to.be.eql([1]);
+        expect(result['b'][1].map((x) => x.id)).to.be.eql([1]);
+        expect(result['b'][2].map((x) => x.id)).to.be.eql([2]);
+        expect(result['c'][2].map((x) => x.id)).to.be.eql([2, 3]);
+        expect(result['d'][2].map((x) => x.id)).to.be.eql([3]);
+      });
+
+      it('should return an array when no properties are informed', async () => {
+        const payload = [
+          {
+            test: ['a', 'b', 'c'],
+            c: 1,
+            d: false,
+            id: 1,
+          },
+          {
+            test: ['b', 'c'],
+            c: 2,
+            d: true,
+            id: 2,
+          },
+          {
+            test: ['c', 'd'],
+            c: 2,
+            d: true,
+            id: 3,
+          },
+        ];
+
+        const result = await fluent(payload).toObjectChainAsync();
+
+        expect(result).to.be.eql(payload);
+      });
+    });
+  });
+
+  describe('asyncIterable', () => {
+    it('should create a object chain based on keyable informed properties', async () => {
+      const payload = Promise.resolve([
+        {
+          test: ['a', 'b', 'c'],
+          c: 1,
+          d: false,
+          id: 1,
+        },
+        {
+          test: ['b', 'c'],
+          c: 2,
+          d: true,
+          id: 2,
+        },
+        {
+          test: ['c', 'd'],
+          c: 2,
+          d: true,
+          id: 3,
+        },
+      ]);
+
+      const result = await fluentAsync(payload).toObjectChain('test', 'c');
+
+      expect(result['a'][1].map((x) => x.id)).to.be.eql([1]);
+      expect(result['b'][1].map((x) => x.id)).to.be.eql([1]);
+      expect(result['b'][2].map((x) => x.id)).to.be.eql([2]);
+      expect(result['c'][2].map((x) => x.id)).to.be.eql([2, 3]);
+      expect(result['d'][2].map((x) => x.id)).to.be.eql([3]);
+    });
+
+    it('should return an array when no properties are informed', async () => {
+      const arr = [
+        {
+          test: ['a', 'b', 'c'],
+          c: 1,
+          d: false,
+          id: 1,
+        },
+        {
+          test: ['b', 'c'],
+          c: 2,
+          d: true,
+          id: 2,
+        },
+        {
+          test: ['c', 'd'],
+          c: 2,
+          d: true,
+          id: 3,
+        },
+      ];
+      const payload = Promise.resolve(arr);
+
+      const result = await fluentAsync(payload).toObjectChain();
+
+      expect(result).to.be.eql(arr);
+    });
+  });
+});


### PR DESCRIPTION
This new operation creates an Object Chain that gives O(1) access to classified items, based on the informed properties.
That's a resolving operation. Here's a practical example:

```
const result = fluent(products).toObjectChain('category', 'brand');

console.log(result['eletronics']?.['asus']) // Prints the list of items of category eletronics, branch asus
```

This also works informing fields that are actually arrays, as toObjectAsync unwinds its values to create multiple ramifications