### PR TITLE
feat: adding unwind operation

### DIFF
--- a/src/async/index.ts
+++ b/src/async/index.ts
@@ -46,5 +46,6 @@ export * from './to-object-async';
 export * from './to-object-chain-async';
 export * from './to-set-async';
 export * from './top-async';
+export * from './unwind-async';
 export * from './wait-all-async';
 export * from './with-index-async';

--- a/src/async/to-object-chain-async.ts
+++ b/src/async/to-object-chain-async.ts
@@ -1,12 +1,12 @@
 import { toObjectChainRecipe } from '../recipes';
 import { basicAsync } from './basic-ingredients-async';
-import { flatJoinAsync } from './flat-join-async';
 import { groupAsync } from './group-async';
 import { toObjectAsync } from './to-object-async';
+import { unwindAsync } from './unwind-async';
 
 export const toObjectChainAsync = toObjectChainRecipe({
   ...basicAsync,
-  flatJoin: flatJoinAsync,
   group: groupAsync,
   toObject: toObjectAsync,
+  unwind: unwindAsync,
 });

--- a/src/async/unwind-async.ts
+++ b/src/async/unwind-async.ts
@@ -1,0 +1,12 @@
+import { unwindRecipe } from '../recipes';
+import { basicAsync } from './basic-ingredients-async';
+import { combineJoinAsync } from './combine-join-async';
+import { flattenAsync } from './flatten-async';
+import { toObjectAsync } from './to-object-async';
+
+export const unwindAsync = unwindRecipe({
+  ...basicAsync,
+  flatten: flattenAsync,
+  combineJoin: combineJoinAsync,
+  toObject: toObjectAsync,
+});

--- a/src/mounters/fluent-async-functions.ts
+++ b/src/mounters/fluent-async-functions.ts
@@ -50,6 +50,7 @@ import {
   toSetAsync,
   flatJoinAsync,
   toObjectChainAsync,
+  unwindAsync,
 } from '../async';
 import {
   combineEmitter,
@@ -101,6 +102,7 @@ export const asyncIterableFuncs = {
   mergeEmitterCatching,
   whenEmpty: whenEmptyAsync,
   catch: catchAsync,
+  unwind: unwindAsync,
 };
 
 export const asyncSpecial = {

--- a/src/mounters/fluent-functions.ts
+++ b/src/mounters/fluent-functions.ts
@@ -53,6 +53,7 @@ import {
   next,
   toSet,
   toObjectChain,
+  unwind,
 } from '../sync';
 import {
   allAsync,
@@ -86,6 +87,7 @@ import {
   toSetAsync,
   flatJoinAsync,
   toObjectChainAsync,
+  unwindAsync,
 } from '../async';
 import { combineEmitter, concatEmitter } from '../emitter';
 import * as common from '../common';
@@ -115,6 +117,7 @@ export const iterableFuncs = {
   combineJoin,
   whenEmpty,
   catch: catchSync,
+  unwind,
 };
 
 export const iterableAsyncFuncs = {
@@ -135,6 +138,7 @@ export const iterableAsyncFuncs = {
   combineEmitter,
   concatEmitter,
   catchAsync,
+  unwindAsync,
 };
 
 export const special = {

--- a/src/recipes/index.ts
+++ b/src/recipes/index.ts
@@ -34,4 +34,5 @@ export * from './to-object-chain-recipe';
 export * from './to-object-recipe';
 export * from './to-set-recipe';
 export * from './top-recipe';
+export * from './unwind-recipe';
 export * from './with-index-recipe';

--- a/src/recipes/ingredients.ts
+++ b/src/recipes/ingredients.ts
@@ -77,8 +77,14 @@ export interface ComparisonIngredients extends BasicIngredients {
   comparer: CompareProvider;
 }
 
-export interface ToObjectChainRecipe extends BasicIngredients {
-  flatJoin: Function;
+export interface UnwindIngredients extends BasicIngredients {
+  flatten: Function;
+  toObject: Function;
+  combineJoin: Function;
+}
+
+export interface ToObjectChainIngredients extends BasicIngredients {
   group: Function;
   toObject: Function;
+  unwind: Function;
 }

--- a/src/recipes/to-object-chain-recipe.ts
+++ b/src/recipes/to-object-chain-recipe.ts
@@ -1,33 +1,32 @@
 import { AnyIterable } from 'augmentative-iterable';
-import { ToObjectChainRecipe } from './ingredients';
-import { head, tail } from '../types';
+import { ToObjectChainIngredients } from './ingredients';
 
 function toObjectNode(
   it: AnyIterable<any>,
   keys: string[],
   index: number,
-  ing: ToObjectChainRecipe,
+  ing: ToObjectChainIngredients,
 ): any {
   const key = keys[index];
-  it = ing.flatJoin.call(it, key);
-  it = ing.group.call(it, (x: any) => x[head]);
+  it = ing.unwind.call(it, key);
+  it = ing.group.call(it, (x: any) => x.unwinded[key]);
   return ing.toObject.call(
     it,
     'key',
     index < keys.length - 1
       ? (subIt: any) =>
           toObjectNode(
-            ing.map.call(subIt.values, (x: any) => x[tail]),
+            ing.map.call(subIt.values, (x: any) => x.value),
             keys,
             index + 1,
             ing,
           )
       : (subIt: any) =>
-          ing.toArray.call(ing.map.call(subIt.values, (x: any) => x[tail])),
+          ing.toArray.call(ing.map.call(subIt.values, (x: any) => x.value)),
   );
 }
 
-export function toObjectChainRecipe(ing: ToObjectChainRecipe) {
+export function toObjectChainRecipe(ing: ToObjectChainIngredients) {
   return function (this: AnyIterable<any>, ...keys: string[]) {
     return keys.length === 0
       ? ing.toArray.call(this)

--- a/src/recipes/unwind-recipe.ts
+++ b/src/recipes/unwind-recipe.ts
@@ -1,0 +1,36 @@
+import { AnyIterable } from 'augmentative-iterable';
+import { UnwindIngredients } from './ingredients';
+
+export function unwindRecipe({
+  resolver,
+  flatten,
+  map,
+  combineJoin,
+  toObject,
+}: UnwindIngredients) {
+  return function (this: AnyIterable<any>, ...keys: string[]) {
+    return flatten.call(this, (value: any) => {
+      const it = map.call(keys, (x) => {
+        const current = value[x];
+        return Array.isArray(current)
+          ? map.call(current, (v) => [x, v])
+          : [[x, current]];
+      });
+      return resolver(combineJoin.call(it), (it2) =>
+        map.call(it2, (unwindedValues) =>
+          resolver(
+            toObject.call(
+              unwindedValues,
+              (u: any) => u[0],
+              (u: any) => u[1],
+            ),
+            (unwinded) => ({
+              unwinded,
+              value,
+            }),
+          ),
+        ),
+      );
+    });
+  };
+}

--- a/src/sync/index.ts
+++ b/src/sync/index.ts
@@ -48,6 +48,7 @@ export * from './to-object';
 export * from './to-object-chain';
 export * from './to-set';
 export * from './top';
+export * from './unwind';
 export * from './wait-all';
 export * from './when-empty';
 export * from './with-index';

--- a/src/sync/to-object-chain.ts
+++ b/src/sync/to-object-chain.ts
@@ -1,12 +1,12 @@
 import { toObjectChainRecipe } from '../recipes';
 import { basic } from './basic-ingredients';
-import { flatJoin } from './flat-join';
 import { group } from './group';
 import { toObject } from './to-object';
+import { unwind } from './unwind';
 
 export const toObjectChain = toObjectChainRecipe({
   ...basic,
-  flatJoin,
   group,
   toObject,
+  unwind,
 });

--- a/src/sync/unwind.ts
+++ b/src/sync/unwind.ts
@@ -1,0 +1,12 @@
+import { unwindRecipe } from '../recipes';
+import { basic } from './basic-ingredients';
+import { combineJoin } from './combine-join';
+import { flatten } from './flatten';
+import { toObject } from './to-object';
+
+export const unwind = unwindRecipe({
+  ...basic,
+  flatten,
+  combineJoin,
+  toObject,
+});

--- a/src/types/fluent-async-iterable.ts
+++ b/src/types/fluent-async-iterable.ts
@@ -62,5 +62,6 @@ declare module './base' {
     whenEmpty: f.AsyncWhenEmptyFunction;
     catch: f.AsyncCatchFunction<T>;
     next: f.AsyncNextFunction<T>;
+    unwind: f.AsyncUnwindFunction<T>;
   }
 }

--- a/src/types/fluent-iterable.ts
+++ b/src/types/fluent-iterable.ts
@@ -94,5 +94,7 @@ declare module './base' {
     catch: f.CatchFunction<T>;
     catchAsync: f.AsyncCatchFunction<T>;
     next: f.NextFunction<T>;
+    unwind: f.UnwindFunction<T>;
+    unwindAsync: f.AsyncUnwindFunction<T>;
   }
 }

--- a/src/types/function-types/index.ts
+++ b/src/types/function-types/index.ts
@@ -53,6 +53,7 @@ export * from './to-object-chain-function';
 export * from './to-object-function';
 export * from './to-set-function';
 export * from './top-function';
+export * from './unwind-function';
 export * from './wait-all-function';
 export * from './when-empty-function';
 export * from './with-index-function';

--- a/src/types/function-types/unwind-function.ts
+++ b/src/types/function-types/unwind-function.ts
@@ -1,0 +1,30 @@
+/* eslint-disable no-magic-numbers */
+import { FluentAsyncIterable, FluentIterable } from '../base';
+
+export type UnwindResult<Arr extends Array<keyof V>, V> = {
+  unwinded: {
+    [k in Arr[number]]: V[k] extends Array<infer T> ? T : V[k];
+  };
+  value: V;
+};
+
+export interface UnwindFunction<T> {
+  /**
+   * Unwinds the specified properties creating a new iterable with multiple items
+   * for each combination of unwinded values for each original item
+   * @param keys The keys to be unwinded
+   * @returns The object chain
+   */
+  <A extends Array<keyof T>>(...keys: A): FluentIterable<UnwindResult<A, T>>;
+}
+export interface AsyncUnwindFunction<T> {
+  /**
+   * Unwinds the specified properties creating a new iterable with multiple items
+   * for each combination of unwinded values for each original item
+   * @param keys The keys to be unwinded
+   * @returns The object chain
+   */
+  <A extends Array<keyof T>>(...keys: A): FluentAsyncIterable<
+    UnwindResult<A, T>
+  >;
+}

--- a/test/unwind.spec.ts
+++ b/test/unwind.spec.ts
@@ -1,0 +1,165 @@
+import { expect } from 'chai';
+import { fluent, fluentAsync } from '../src';
+
+describe('unwind', () => {
+  describe('iterable', () => {
+    describe('sync', () => {
+      it('should unwind specified properties', () => {
+        const payload = [
+          {
+            test: ['a', 'b', 'c'],
+            c: 1,
+            d: false,
+            id: 1,
+          },
+          {
+            test: ['b', 'c'],
+            c: 2,
+            d: true,
+            id: 2,
+          },
+          {
+            test: ['c', 'd'],
+            c: 2,
+            d: true,
+            id: 3,
+          },
+        ];
+
+        const it = fluent(payload).unwind('test', 'c');
+        const result = it.toArray();
+
+        expect(
+          result
+            .filter((x) => x.unwinded.test === 'a' && x.unwinded.c === 1)!
+            .map((x) => x.value.id),
+        ).to.be.eql([1]);
+        expect(
+          result
+            .filter((x) => x.unwinded.test === 'b' && x.unwinded.c === 1)!
+            .map((x) => x.value.id),
+        ).to.be.eql([1]);
+        expect(
+          result
+            .filter((x) => x.unwinded.test === 'b' && x.unwinded.c === 2)!
+            .map((x) => x.value.id),
+        ).to.be.eql([2]);
+        expect(
+          result
+            .filter((x) => x.unwinded.test === 'c' && x.unwinded.c === 2)!
+            .map((x) => x.value.id),
+        ).to.be.eql([2, 3]);
+        expect(
+          result
+            .filter((x) => x.unwinded.test === 'd' && x.unwinded.c === 2)!
+            .map((x) => x.value.id),
+        ).to.be.eql([3]);
+      });
+    });
+    describe('async', () => {
+      it('should unwind specified properties for unwindAsync', async () => {
+        const payload = [
+          {
+            test: ['a', 'b', 'c'],
+            c: 1,
+            d: false,
+            id: 1,
+          },
+          {
+            test: ['b', 'c'],
+            c: 2,
+            d: true,
+            id: 2,
+          },
+          {
+            test: ['c', 'd'],
+            c: 2,
+            d: true,
+            id: 3,
+          },
+        ];
+
+        const it = fluent(payload).unwindAsync('test', 'c');
+        const result = await it.toArray();
+
+        expect(
+          result
+            .filter((x) => x.unwinded.test === 'a' && x.unwinded.c === 1)!
+            .map((x) => x.value.id),
+        ).to.be.eql([1]);
+        expect(
+          result
+            .filter((x) => x.unwinded.test === 'b' && x.unwinded.c === 1)!
+            .map((x) => x.value.id),
+        ).to.be.eql([1]);
+        expect(
+          result
+            .filter((x) => x.unwinded.test === 'b' && x.unwinded.c === 2)!
+            .map((x) => x.value.id),
+        ).to.be.eql([2]);
+        expect(
+          result
+            .filter((x) => x.unwinded.test === 'c' && x.unwinded.c === 2)!
+            .map((x) => x.value.id),
+        ).to.be.eql([2, 3]);
+        expect(
+          result
+            .filter((x) => x.unwinded.test === 'd' && x.unwinded.c === 2)!
+            .map((x) => x.value.id),
+        ).to.be.eql([3]);
+      });
+
+      it('should unwind specified properties for an async iterable', async () => {
+        const payload = Promise.resolve([
+          {
+            test: ['a', 'b', 'c'],
+            c: 1,
+            d: false,
+            id: 1,
+          },
+          {
+            test: ['b', 'c'],
+            c: 2,
+            d: true,
+            id: 2,
+          },
+          {
+            test: ['c', 'd'],
+            c: 2,
+            d: true,
+            id: 3,
+          },
+        ]);
+
+        const it = fluentAsync(payload).unwind('test', 'c');
+        const result = await it.toArray();
+
+        expect(
+          result
+            .filter((x) => x.unwinded.test === 'a' && x.unwinded.c === 1)!
+            .map((x) => x.value.id),
+        ).to.be.eql([1]);
+        expect(
+          result
+            .filter((x) => x.unwinded.test === 'b' && x.unwinded.c === 1)!
+            .map((x) => x.value.id),
+        ).to.be.eql([1]);
+        expect(
+          result
+            .filter((x) => x.unwinded.test === 'b' && x.unwinded.c === 2)!
+            .map((x) => x.value.id),
+        ).to.be.eql([2]);
+        expect(
+          result
+            .filter((x) => x.unwinded.test === 'c' && x.unwinded.c === 2)!
+            .map((x) => x.value.id),
+        ).to.be.eql([2, 3]);
+        expect(
+          result
+            .filter((x) => x.unwinded.test === 'd' && x.unwinded.c === 2)!
+            .map((x) => x.value.id),
+        ).to.be.eql([3]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
unwind operation generates a new iterable with two properties:
* unwinded, containing the unwinded properties
* value, containing the original value;

It works similarly to unwind on mongo, where you generate N items from 1, based on a list property with N values.
I also stopped using flatJoin for toObjectChain and started to use this new unwind operation, as it's a bit lighter and delivers what toObjectChain needs to work