### PR TITLE
fix: making unwind unwinds any iterable

### DIFF
--- a/src/async/unwind-async.ts
+++ b/src/async/unwind-async.ts
@@ -9,4 +9,5 @@ export const unwindAsync = unwindRecipe({
   flatten: flattenAsync,
   combineJoin: combineJoinAsync,
   toObject: toObjectAsync,
+  symbols: [Symbol.iterator, Symbol.asyncIterator],
 });

--- a/src/recipes/ingredients.ts
+++ b/src/recipes/ingredients.ts
@@ -81,6 +81,7 @@ export interface UnwindIngredients extends BasicIngredients {
   flatten: Function;
   toObject: Function;
   combineJoin: Function;
+  symbols: Symbol[];
 }
 
 export interface ToObjectChainIngredients extends BasicIngredients {

--- a/src/recipes/unwind-recipe.ts
+++ b/src/recipes/unwind-recipe.ts
@@ -7,12 +7,13 @@ export function unwindRecipe({
   map,
   combineJoin,
   toObject,
+  symbols,
 }: UnwindIngredients) {
   return function (this: AnyIterable<any>, ...keys: string[]) {
     return flatten.call(this, (value: any) => {
       const it = map.call(keys, (x) => {
         const current = value[x];
-        return Array.isArray(current)
+        return symbols.some((symbol) => typeof current[symbol as keyof typeof current] === 'function')
           ? map.call(current, (v) => [x, v])
           : [[x, current]];
       });

--- a/src/recipes/unwind-recipe.ts
+++ b/src/recipes/unwind-recipe.ts
@@ -13,7 +13,10 @@ export function unwindRecipe({
     return flatten.call(this, (value: any) => {
       const it = map.call(keys, (x) => {
         const current = value[x];
-        return symbols.some((symbol) => typeof current[symbol as keyof typeof current] === 'function')
+        return symbols.some(
+          (symbol) =>
+            typeof current[symbol as keyof typeof current] === 'function',
+        )
           ? map.call(current, (v) => [x, v])
           : [[x, current]];
       });

--- a/src/sync/unwind.ts
+++ b/src/sync/unwind.ts
@@ -9,4 +9,5 @@ export const unwind = unwindRecipe({
   flatten,
   combineJoin,
   toObject,
+  symbols: [Symbol.iterator],
 });

--- a/src/types/fluent-async-iterable.ts
+++ b/src/types/fluent-async-iterable.ts
@@ -62,6 +62,6 @@ declare module './base' {
     whenEmpty: f.AsyncWhenEmptyFunction;
     catch: f.AsyncCatchFunction<T>;
     next: f.AsyncNextFunction<T>;
-    unwind: f.AsyncUnwindFunction<T>;
+    unwind: f.UnwindFunction<T, 'async'>;
   }
 }

--- a/src/types/fluent-iterable.ts
+++ b/src/types/fluent-iterable.ts
@@ -94,7 +94,7 @@ declare module './base' {
     catch: f.CatchFunction<T>;
     catchAsync: f.AsyncCatchFunction<T>;
     next: f.NextFunction<T>;
-    unwind: f.UnwindFunction<T>;
-    unwindAsync: f.AsyncUnwindFunction<T>;
+    unwind: f.UnwindFunction<T, 'sync'>;
+    unwindAsync: f.UnwindFunction<T, 'async'>;
   }
 }

--- a/src/types/function-types/unwind-function.ts
+++ b/src/types/function-types/unwind-function.ts
@@ -2,16 +2,19 @@ import { AnyIterable } from 'augmentative-iterable';
 /* eslint-disable no-magic-numbers */
 import { FluentAsyncIterable, FluentIterable } from '../base';
 
+export type ExtractItemType<V> = V extends Iterable<infer T> ? T : V;
+export type ExtractAsyncItemType<V> = V extends AnyIterable<infer T> ? T : V;
+
 export type UnwindResult<Arr extends Array<keyof V>, V> = {
   unwinded: {
-    [k in Arr[number]]: V[k] extends Iterable<infer T> ? T : V[k];
+    [k in Arr[number]]: ExtractItemType<V[k]>;
   };
   value: V;
 };
 
 export type AsyncUnwindResult<Arr extends Array<keyof V>, V> = {
   unwinded: {
-    [k in Arr[number]]: V[k] extends AnyIterable<infer T> ? T : V[k];
+    [k in Arr[number]]: ExtractAsyncItemType<V[k]>;
   };
   value: V;
 };

--- a/src/types/function-types/unwind-function.ts
+++ b/src/types/function-types/unwind-function.ts
@@ -1,41 +1,31 @@
-import { AnyIterable } from 'augmentative-iterable';
+import { AsyncItemType } from './../base';
 /* eslint-disable no-magic-numbers */
+import { AnyIterable } from 'augmentative-iterable';
 import { FluentAsyncIterable, FluentIterable } from '../base';
 
-export type ExtractItemType<V> = V extends Iterable<infer T> ? T : V;
-export type ExtractAsyncItemType<V> = V extends AnyIterable<infer T> ? T : V;
-
-export type UnwindResult<Arr extends Array<keyof V>, V> = {
+export type UnwindResult<
+  Arr extends Array<keyof V>,
+  V,
+  Type extends 'sync' | 'async',
+> = {
   unwinded: {
-    [k in Arr[number]]: ExtractItemType<V[k]>;
+    [k in Arr[number]]: V[k] extends (
+      Type extends 'sync' ? Iterable<any> : AnyIterable<any>
+    )
+      ? AsyncItemType<V[k]>
+      : V[k];
   };
   value: V;
 };
 
-export type AsyncUnwindResult<Arr extends Array<keyof V>, V> = {
-  unwinded: {
-    [k in Arr[number]]: ExtractAsyncItemType<V[k]>;
-  };
-  value: V;
-};
-
-export interface UnwindFunction<T> {
+export interface UnwindFunction<T, Type extends 'sync' | 'async'> {
   /**
    * Unwinds the specified properties creating a new iterable with multiple items
    * for each combination of unwinded values for each original item
    * @param keys The keys to be unwinded
    * @returns The object chain
    */
-  <A extends Array<keyof T>>(...keys: A): FluentIterable<UnwindResult<A, T>>;
-}
-export interface AsyncUnwindFunction<T> {
-  /**
-   * Unwinds the specified properties creating a new iterable with multiple items
-   * for each combination of unwinded values for each original item
-   * @param keys The keys to be unwinded
-   * @returns The object chain
-   */
-  <A extends Array<keyof T>>(...keys: A): FluentAsyncIterable<
-    AsyncUnwindResult<A, T>
-  >;
+  <A extends Array<keyof T>>(...keys: A): Type extends 'sync'
+    ? FluentIterable<UnwindResult<A, T, Type>>
+    : FluentAsyncIterable<UnwindResult<A, T, Type>>;
 }

--- a/src/types/function-types/unwind-function.ts
+++ b/src/types/function-types/unwind-function.ts
@@ -1,9 +1,17 @@
+import { AnyIterable } from 'augmentative-iterable';
 /* eslint-disable no-magic-numbers */
 import { FluentAsyncIterable, FluentIterable } from '../base';
 
 export type UnwindResult<Arr extends Array<keyof V>, V> = {
   unwinded: {
-    [k in Arr[number]]: V[k] extends Array<infer T> ? T : V[k];
+    [k in Arr[number]]: V[k] extends Iterable<infer T> ? T : V[k];
+  };
+  value: V;
+};
+
+export type AsyncUnwindResult<Arr extends Array<keyof V>, V> = {
+  unwinded: {
+    [k in Arr[number]]: V[k] extends AnyIterable<infer T> ? T : V[k];
   };
   value: V;
 };
@@ -25,6 +33,6 @@ export interface AsyncUnwindFunction<T> {
    * @returns The object chain
    */
   <A extends Array<keyof T>>(...keys: A): FluentAsyncIterable<
-    UnwindResult<A, T>
+    AsyncUnwindResult<A, T>
   >;
 }

--- a/test/unwind.spec.ts
+++ b/test/unwind.spec.ts
@@ -14,7 +14,7 @@ describe('unwind', () => {
           },
           {
             test: ['b', 'c'],
-            c: [2, 3],
+            c: new Set([2, 3]),
             d: true,
             id: 2,
           },
@@ -56,19 +56,19 @@ describe('unwind', () => {
           },
           {
             unwinded: { test: 'b', c: 2 },
-            value: { test: ['b', 'c'], c: [2, 3], d: true, id: 2 },
+            value: { test: ['b', 'c'], c: new Set([2, 3]), d: true, id: 2 },
           },
           {
             unwinded: { test: 'b', c: 3 },
-            value: { test: ['b', 'c'], c: [2, 3], d: true, id: 2 },
+            value: { test: ['b', 'c'], c: new Set([2, 3]), d: true, id: 2 },
           },
           {
             unwinded: { test: 'c', c: 2 },
-            value: { test: ['b', 'c'], c: [2, 3], d: true, id: 2 },
+            value: { test: ['b', 'c'], c: new Set([2, 3]), d: true, id: 2 },
           },
           {
             unwinded: { test: 'c', c: 3 },
-            value: { test: ['b', 'c'], c: [2, 3], d: true, id: 2 },
+            value: { test: ['b', 'c'], c: new Set([2, 3]), d: true, id: 2 },
           },
           {
             unwinded: { test: 'c', c: 2 },


### PR DESCRIPTION
Unwind was only unwinding array fields, but with this change it can unwinds any iterable type (or async iterables, if you are using a fluent async iterable)