### PR TITLE
Readonly array to object chain

### DIFF
--- a/src/types/function-types/to-object-chain-function.ts
+++ b/src/types/function-types/to-object-chain-function.ts
@@ -41,7 +41,9 @@ export type RecordChain<
   any: any;
   recur: V[Arr[Pos]] extends string | number | symbol
     ? Record<V[Arr[Pos]], RecordChain<Arr, V, R, Indexes[Pos]>>
-    : V[Arr[Pos]] extends Array<string | number | symbol>
+    : V[Arr[Pos]] extends
+        | Array<string | symbol | number>
+        | ReadonlyArray<string | number | symbol>
     ? Record<ItemType<V[Arr[Pos]]>, RecordChain<Arr, V, R, Indexes[Pos]>>
     : never;
 }[Pos extends Arr['length'] ? 'done' : Pos extends -1 ? 'any' : 'recur'];

--- a/src/types/function-types/to-object-chain-function.ts
+++ b/src/types/function-types/to-object-chain-function.ts
@@ -5,7 +5,8 @@ export type ChainKeyType =
   | string
   | symbol
   | number
-  | Array<string | symbol | number>;
+  | Array<string | symbol | number>
+  | ReadonlyArray<string | symbol | number>;
 type Indexes = [
   1,
   2,

--- a/test/to-object-chain.spec.ts
+++ b/test/to-object-chain.spec.ts
@@ -5,7 +5,12 @@ describe('toObjectChain', () => {
   describe('iterable', () => {
     describe('sync', () => {
       it('should create a object chain based on keyable informed properties', () => {
-        const payload = [
+        const payload: {
+          test: readonly string[];
+          c: number;
+          d: boolean;
+          id: number;
+        }[] = [
           {
             test: ['a', 'b', 'c'],
             c: 1,


### PR DESCRIPTION
You can freeze the object during some fluent iteration to guarantee that nobody will mutate it. This is not something fluent will do by itself, but it's useful, especially if you're creating reusable structures.

The thing is that toObjectChain. does not support read-only arrays as key indexers, which limits your use of such a feature. This PR removes that limitation.