### PR TITLE
feat: accepting function mapping for to object chain

### DIFF
--- a/src/async/to-object-chain-async.ts
+++ b/src/async/to-object-chain-async.ts
@@ -1,14 +1,14 @@
 import { toObjectChainRecipe } from '../recipes';
 import { basicAsync } from './basic-ingredients-async';
+import { flattenAsync } from './flatten-async';
 import { groupAsync } from './group-async';
 import { reduceAsync } from './reduce-async';
 import { toObjectAsync } from './to-object-async';
-import { unwindAsync } from './unwind-async';
 
 export const toObjectChainAsync = toObjectChainRecipe({
   ...basicAsync,
   group: groupAsync,
   toObject: toObjectAsync,
-  unwind: unwindAsync,
+  flatten: flattenAsync,
   reduce: reduceAsync,
 });

--- a/src/async/to-object-chain-reduce-async.ts
+++ b/src/async/to-object-chain-reduce-async.ts
@@ -1,14 +1,14 @@
 import { toObjectChainReduceRecipe } from '../recipes';
 import { basicAsync } from './basic-ingredients-async';
+import { flattenAsync } from './flatten-async';
 import { groupAsync } from './group-async';
 import { reduceAsync } from './reduce-async';
 import { toObjectAsync } from './to-object-async';
-import { unwindAsync } from './unwind-async';
 
 export const toObjectChainReduceAsync = toObjectChainReduceRecipe({
   ...basicAsync,
   group: groupAsync,
   toObject: toObjectAsync,
-  unwind: unwindAsync,
+  flatten: flattenAsync,
   reduce: reduceAsync,
 });

--- a/src/recipes/ingredients.ts
+++ b/src/recipes/ingredients.ts
@@ -87,6 +87,6 @@ export interface UnwindIngredients extends BasicIngredients {
 export interface ToObjectChainIngredients extends BasicIngredients {
   group: Function;
   toObject: Function;
-  unwind: Function;
+  flatten: Function;
   reduce: AsyncReducer<any, any>;
 }

--- a/src/recipes/to-object-chain-reduce-recipe.ts
+++ b/src/recipes/to-object-chain-reduce-recipe.ts
@@ -1,25 +1,41 @@
+import { FunctionAnyMapper } from './../types/any-mapper';
 import { AnyIterable } from 'augmentative-iterable';
 import { AsyncReducer } from '../types';
 import { ToObjectChainIngredients } from './ingredients';
+import { prepare } from '../types-internal/prepare';
+
+function unwindAndGroup(
+  it: AnyIterable<any>,
+  ing: ToObjectChainIngredients,
+  key: FunctionAnyMapper<any>,
+) {
+  it = ing.flatten.call(it, (x: any) => {
+    const current = key(x);
+    return typeof current !== 'string' &&
+      typeof current[Symbol.iterator] === 'function'
+      ? ing.map.call(current, (item) => [item, x])
+      : [[current, x]];
+  });
+  return ing.group.call(it, (x: any) => x[0]);
+}
 
 function toObjectNode<T, R>(
   it: AnyIterable<any>,
-  keys: string[],
+  keys: FunctionAnyMapper<any>[],
   index: number,
   ing: ToObjectChainIngredients,
   reducer: AsyncReducer<T, R>,
   initial: () => R,
 ): any {
   const key = keys[index];
-  it = ing.unwind.call(it, key);
-  it = ing.group.call(it, (x: any) => x.unwinded[key]);
+  it = unwindAndGroup(it, ing, key);
   return ing.toObject.call(
     it,
     'key',
     index < keys.length - 1
       ? (subIt: any) =>
           toObjectNode(
-            ing.map.call(subIt.values, (x: any) => x.value),
+            ing.map.call(subIt.values, (x: any) => x[1]),
             keys,
             index + 1,
             ing,
@@ -28,7 +44,7 @@ function toObjectNode<T, R>(
           )
       : (subIt: any) =>
           ing.reduce.call(
-            ing.map.call(subIt.values, (x: any) => x.value),
+            ing.map.call(subIt.values, (x: any) => x[1]),
             reducer,
             initial(),
           ),
@@ -42,8 +58,9 @@ export function toObjectChainReduceRecipe(ing: ToObjectChainIngredients) {
     reducer: AsyncReducer<T, R>,
     ...keys: string[]
   ) {
+    const prepared = keys.map((x) => prepare(x));
     return keys.length === 0
       ? ing.reduce.call(this, reducer, initial())
-      : toObjectNode(this, keys, 0, ing, reducer, initial);
+      : toObjectNode(this, prepared, 0, ing, reducer, initial);
   };
 }

--- a/src/recipes/to-object-chain-reduce-recipe.ts
+++ b/src/recipes/to-object-chain-reduce-recipe.ts
@@ -16,7 +16,11 @@ function unwindAndGroup(
       ? ing.map.call(current, (item) => [item, x])
       : [[current, x]];
   });
-  return ing.group.call(it, (x: any) => x[0]);
+  return ing.group.call(
+    it,
+    (x: any) => x[0],
+    (_k: any, v: any) => [v[1]],
+  );
 }
 
 function toObjectNode<T, R>(
@@ -34,20 +38,8 @@ function toObjectNode<T, R>(
     'key',
     index < keys.length - 1
       ? (subIt: any) =>
-          toObjectNode(
-            ing.map.call(subIt.values, (x: any) => x[1]),
-            keys,
-            index + 1,
-            ing,
-            reducer,
-            initial,
-          )
-      : (subIt: any) =>
-          ing.reduce.call(
-            ing.map.call(subIt.values, (x: any) => x[1]),
-            reducer,
-            initial(),
-          ),
+          toObjectNode(subIt.values, keys, index + 1, ing, reducer, initial)
+      : (subIt: any) => ing.reduce.call(subIt.values, reducer, initial()),
   );
 }
 

--- a/src/sync/to-object-chain-reduce.ts
+++ b/src/sync/to-object-chain-reduce.ts
@@ -1,14 +1,14 @@
 import { toObjectChainReduceRecipe } from '../recipes';
 import { basic } from './basic-ingredients';
+import { flatten } from './flatten';
 import { group } from './group';
 import { reduce } from './reduce';
 import { toObject } from './to-object';
-import { unwind } from './unwind';
 
 export const toObjectChainReduce = toObjectChainReduceRecipe({
   ...basic,
   group,
   toObject,
-  unwind,
+  flatten,
   reduce,
 });

--- a/src/sync/to-object-chain.ts
+++ b/src/sync/to-object-chain.ts
@@ -1,14 +1,14 @@
 import { toObjectChainRecipe } from '../recipes';
 import { basic } from './basic-ingredients';
+import { flatten } from './flatten';
 import { group } from './group';
 import { reduce } from './reduce';
 import { toObject } from './to-object';
-import { unwind } from './unwind';
 
 export const toObjectChain = toObjectChainRecipe({
   ...basic,
   group,
   toObject,
-  unwind,
+  flatten,
   reduce,
 });

--- a/src/types/function-types/to-object-chain-function.ts
+++ b/src/types/function-types/to-object-chain-function.ts
@@ -5,8 +5,14 @@ export type ChainKeyType =
   | string
   | symbol
   | number
-  | Array<string | symbol | number>
-  | ReadonlyArray<string | symbol | number>;
+  | Iterable<string | symbol | number>;
+
+export type ToObjectChainFuncMap<T> = (x: T) => ChainKeyType;
+
+export type ToObjectChainKey<T> =
+  | KeysOfType<T, ChainKeyType>
+  | ToObjectChainFuncMap<T>;
+
 export type Indexes = [
   1,
   2,
@@ -31,20 +37,35 @@ export type Indexes = [
   -1,
 ];
 
+export type ToObjectChainValueOf<
+  V,
+  K extends ToObjectChainKey<V>,
+> = K extends ToObjectChainFuncMap<V>
+  ? ReturnType<K>
+  : K extends keyof V
+  ? V[K]
+  : never;
+
 export type RecordChain<
-  Arr extends Array<KeysOfType<V, ChainKeyType>>,
+  Arr extends Array<ToObjectChainKey<V>>,
   V,
   R = V[],
   Pos extends number = 0,
 > = {
   done: R;
   any: any;
-  recur: V[Arr[Pos]] extends string | number | symbol
-    ? Record<V[Arr[Pos]], RecordChain<Arr, V, R, Indexes[Pos]>>
-    : V[Arr[Pos]] extends
+  recur: ToObjectChainValueOf<V, Arr[Pos]> extends string | number | symbol
+    ? Record<
+        ToObjectChainValueOf<V, Arr[Pos]>,
+        RecordChain<Arr, V, R, Indexes[Pos]>
+      >
+    : ToObjectChainValueOf<V, Arr[Pos]> extends
         | Array<string | symbol | number>
         | ReadonlyArray<string | number | symbol>
-    ? Record<ItemType<V[Arr[Pos]]>, RecordChain<Arr, V, R, Indexes[Pos]>>
+    ? Record<
+        ItemType<ToObjectChainValueOf<V, Arr[Pos]>>,
+        RecordChain<Arr, V, R, Indexes[Pos]>
+      >
     : never;
 }[Pos extends Arr['length'] ? 'done' : Pos extends -1 ? 'any' : 'recur'];
 
@@ -55,16 +76,16 @@ export interface ToObjectChainFunction<T> {
    * @param keys The keys to be chained
    * @returns The object chain
    */
-  <A extends Array<KeysOfType<T, ChainKeyType>>>(...keys: A): RecordChain<A, T>;
+  <A extends Array<ToObjectChainKey<T>>>(...keys: A): RecordChain<A, T>;
 }
 export interface AsyncToObjectChainFunction<T> {
   /**
    * Creates an object chain with the values of the specified fields where the latest
    * value in the chain will be the iterable item itself. This is a resolving operation
-   * @param keys The keys to be chained
+   * @param keys The keys to be chained. It can be either property names or mapping functions
    * @returns The object chain
    */
-  <A extends Array<KeysOfType<T, ChainKeyType>>>(...keys: A): Promise<
+  <A extends Array<ToObjectChainKey<T>>>(...keys: A): Promise<
     RecordChain<A, T>
   >;
 }
@@ -75,10 +96,10 @@ export interface ToObjectChainReduceFunction<T> {
    * value in the chain will be the iterable item itself. This is a resolving operation
    * @param initial An initializer function to define the base value for each leaf
    * @param reduce: A reduce function to accumulate the leaf value for each value that fits it
-   * @param keys The keys to be chained
+   * @param keys The keys to be chained. It can be either property names or mapping functions
    * @returns The object chain
    */
-  <A extends Array<KeysOfType<T, ChainKeyType>>, R>(
+  <A extends Array<ToObjectChainKey<T>>, R>(
     initial: () => R,
     reduce: Reducer<T, R>,
     ...keys: A
@@ -90,10 +111,10 @@ export interface AsyncToObjectChainReduceFunction<T> {
    * value in the chain will be the iterable item itself. This is a resolving operation
    * @param initial An initializer function to define the base value for each leaf
    * @param reduce: A reduce function to accumulate the leaf value for each value that fits it
-   * @param keys The keys to be chained
+   * @param keys The keys to be chained. It can be either property names or mapping functions
    * @returns The object chain
    */
-  <A extends Array<KeysOfType<T, ChainKeyType>>, R>(
+  <A extends Array<ToObjectChainKey<T>>, R>(
     initial: () => R,
     reduce: AsyncReducer<T, R>,
     ...keys: A

--- a/src/types/function-types/to-object-chain-function.ts
+++ b/src/types/function-types/to-object-chain-function.ts
@@ -1,11 +1,9 @@
 /* eslint-disable no-magic-numbers */
 import { AsyncReducer, ItemType, KeysOfType, Reducer } from '../base';
 
-export type ChainKeyType =
-  | string
-  | symbol
-  | number
-  | Iterable<string | symbol | number>;
+export type BaseChainKeyType = string | symbol | number;
+
+export type ChainKeyType = BaseChainKeyType | Iterable<BaseChainKeyType>;
 
 export type ToObjectChainFuncMap<T> = (x: T) => ChainKeyType;
 
@@ -54,14 +52,12 @@ export type RecordChain<
 > = {
   done: R;
   any: any;
-  recur: ToObjectChainValueOf<V, Arr[Pos]> extends string | number | symbol
+  recur: ToObjectChainValueOf<V, Arr[Pos]> extends BaseChainKeyType
     ? Record<
         ToObjectChainValueOf<V, Arr[Pos]>,
         RecordChain<Arr, V, R, Indexes[Pos]>
       >
-    : ToObjectChainValueOf<V, Arr[Pos]> extends
-        | Array<string | symbol | number>
-        | ReadonlyArray<string | number | symbol>
+    : ToObjectChainValueOf<V, Arr[Pos]> extends Iterable<BaseChainKeyType>
     ? Record<
         ItemType<ToObjectChainValueOf<V, Arr[Pos]>>,
         RecordChain<Arr, V, R, Indexes[Pos]>

--- a/test/to-object-chain.spec.ts
+++ b/test/to-object-chain.spec.ts
@@ -40,6 +40,45 @@ describe('toObjectChain', () => {
         expect(result['d'][2].map((x) => x.id)).to.be.eql([3]);
       });
 
+      it('should create a object chain based on function mapping informed parameters', () => {
+        const payload: {
+          test: readonly string[];
+          c: number;
+          d: boolean;
+          id: number;
+        }[] = [
+          {
+            test: ['a', 'b', 'c'],
+            c: 1,
+            d: false,
+            id: 1,
+          },
+          {
+            test: ['b', 'c'],
+            c: 2,
+            d: true,
+            id: 2,
+          },
+          {
+            test: ['c', 'd'],
+            c: 2,
+            d: true,
+            id: 3,
+          },
+        ];
+
+        const result = fluent(payload).toObjectChain(
+          (x) => x.test,
+          (x) => x.c,
+        );
+
+        expect(result['a'][1].map((x) => x.id)).to.be.eql([1]);
+        expect(result['b'][1].map((x) => x.id)).to.be.eql([1]);
+        expect(result['b'][2].map((x) => x.id)).to.be.eql([2]);
+        expect(result['c'][2].map((x) => x.id)).to.be.eql([2, 3]);
+        expect(result['d'][2].map((x) => x.id)).to.be.eql([3]);
+      });
+
       it('should return an array when no properties are informed', () => {
         const payload = [
           {
@@ -91,6 +130,40 @@ describe('toObjectChain', () => {
         ];
 
         const result = await fluent(payload).toObjectChainAsync('test', 'c');
+
+        expect(result['a'][1].map((x) => x.id)).to.be.eql([1]);
+        expect(result['b'][1].map((x) => x.id)).to.be.eql([1]);
+        expect(result['b'][2].map((x) => x.id)).to.be.eql([2]);
+        expect(result['c'][2].map((x) => x.id)).to.be.eql([2, 3]);
+        expect(result['d'][2].map((x) => x.id)).to.be.eql([3]);
+      });
+
+      it('should create a object chain based on function mapping informed parameters', async () => {
+        const payload = [
+          {
+            test: ['a', 'b', 'c'],
+            c: 1,
+            d: false,
+            id: 1,
+          },
+          {
+            test: ['b', 'c'],
+            c: 2,
+            d: true,
+            id: 2,
+          },
+          {
+            test: ['c', 'd'],
+            c: 2,
+            d: true,
+            id: 3,
+          },
+        ];
+
+        const result = await fluent(payload).toObjectChainAsync(
+          (x) => x.test,
+          (x) => x.c,
+        );
 
         expect(result['a'][1].map((x) => x.id)).to.be.eql([1]);
         expect(result['b'][1].map((x) => x.id)).to.be.eql([1]);


### PR DESCRIPTION
This PR enables toObjectChain and toObjectChainReduce to accept not only property names but also function mappers