### PR TITLE
feat: implementing distinctby

### DIFF
--- a/src/async/distinct-by-async.ts
+++ b/src/async/distinct-by-async.ts
@@ -1,0 +1,19 @@
+import { distinctByRecipe } from '../recipes';
+import { filterAsync } from './filter-async';
+import { hasLessOrExactlyAsync } from './has-less-or-exactly-async';
+import { basicAsync } from './basic-ingredients-async';
+import { partitionAsync } from './partition-async';
+import { Ingredient, ResolverIngredient } from '../recipes/ingredients';
+import { reduceAsync } from './reduce-async';
+
+function distinctAsyncRecipe(filterOrAll: Ingredient | ResolverIngredient) {
+  return distinctByRecipe({
+    ...basicAsync,
+    partition: partitionAsync,
+    filterOrAll,
+    hasLessOrExactly: hasLessOrExactlyAsync,
+    reduce: reduceAsync,
+  });
+}
+
+export const distinctByAsync = distinctAsyncRecipe(filterAsync);

--- a/src/async/index.ts
+++ b/src/async/index.ts
@@ -8,6 +8,7 @@ export * from './concat-async';
 export * from './contains-async';
 export * from './count-async';
 export * from './distinct-async';
+export * from './distinct-by-async';
 export * from './emit-async';
 export * from './execute-async';
 export * from './filter-async';

--- a/src/mounters/fluent-async-functions.ts
+++ b/src/mounters/fluent-async-functions.ts
@@ -53,6 +53,7 @@ import {
   unwindAsync,
   finallyAsync,
   toObjectChainReduceAsync,
+  distinctByAsync,
 } from '../async';
 import {
   combineEmitter,
@@ -92,6 +93,7 @@ export const asyncIterableFuncs = {
   sort: sortAsync,
   sortBy: sortByAsync,
   distinct: distinctAsync,
+  distinctBy: distinctByAsync,
   distinctAsync,
   execute: executeAsync,
   merge,

--- a/src/mounters/fluent-functions.ts
+++ b/src/mounters/fluent-functions.ts
@@ -1,3 +1,4 @@
+import { distinctByAsync } from './../async/distinct-by-async';
 import {
   any,
   contains,
@@ -31,6 +32,7 @@ import {
   sort,
   sortBy,
   distinct,
+  distinctBy,
   group,
   last,
   all,
@@ -116,6 +118,7 @@ export const iterableFuncs = {
   sort,
   sortBy,
   distinct,
+  distinctBy,
   execute,
   combine,
   combineJoin,
@@ -136,6 +139,7 @@ export const iterableAsyncFuncs = {
   flatMerge,
   flatMapAsync: flattenAsync,
   distinctAsync,
+  distinctByAsync,
   executeAsync,
   toAsync,
   combineAsync,

--- a/src/recipes/distinct-by-recipe.ts
+++ b/src/recipes/distinct-by-recipe.ts
@@ -1,0 +1,51 @@
+import { AnyIterable } from 'augmentative-iterable';
+import { AnyMapper, FunctionAnyMapper } from '../types-internal';
+import { DistinctIngredients } from './ingredients';
+import { prepare } from '../types-internal/prepare';
+
+function chooseDistinctByRecipe({ forEach, resolver }: DistinctIngredients) {
+  return function distinct<T>(
+    this: AnyIterable<T>,
+    mappers: FunctionAnyMapper<any>[],
+  ) {
+    const { length } = mappers;
+    const setPos = length - 1;
+    const lastMap = setPos - 1;
+    const map = setPos === 0 ? new Set() : new Map();
+    const result: any[] = [];
+
+    return resolver(
+      forEach.call(this, (x) => {
+        let current: any = map;
+        for (let i = 0; i < setPos; i++) {
+          const mapper = mappers[i];
+          const k = mapper(x);
+          const prev = current;
+          current = prev.get(k);
+          if (!current) {
+            current = i === lastMap ? new Set() : new Map();
+            prev.set(k, current);
+          }
+        }
+        const k = mappers[setPos](x);
+        if (!current.has(k)) {
+          current.add(k);
+          result.push(x);
+        }
+      }),
+      () => result,
+    );
+  };
+}
+
+export function distinctByRecipe(ingredients: DistinctIngredients) {
+  const choose = chooseDistinctByRecipe(ingredients);
+
+  return function distinctBy<T>(
+    this: AnyIterable<T>,
+    ...baseMappers: Array<AnyMapper<T>>
+  ) {
+    const mappers = baseMappers.map(prepare);
+    return choose.call(this, mappers);
+  };
+}

--- a/src/recipes/index.ts
+++ b/src/recipes/index.ts
@@ -6,6 +6,7 @@ export * from './comparison-recipe';
 export * from './concat-recipe';
 export * from './contains-recipe';
 export * from './count-recipe';
+export * from './distinct-by-recipe';
 export * from './distinct-recipe';
 export * from './emit-recipe';
 export * from './execute-recipe';

--- a/src/sync/distinct-by.ts
+++ b/src/sync/distinct-by.ts
@@ -1,0 +1,19 @@
+import { basic } from './basic-ingredients';
+import { distinctByRecipe } from '../recipes';
+import { filter } from './filter';
+import { hasLessOrExactly } from './has-less-or-exactly';
+import { partition } from './partition';
+import { reduce } from './reduce';
+import { Ingredient, ResolverIngredient } from '../recipes/ingredients';
+
+function distinctSyncRecipe(filterOrAll: Ingredient | ResolverIngredient) {
+  return distinctByRecipe({
+    ...basic,
+    partition,
+    filterOrAll,
+    hasLessOrExactly,
+    reduce,
+  });
+}
+
+export const distinctBy = distinctSyncRecipe(filter);

--- a/src/sync/index.ts
+++ b/src/sync/index.ts
@@ -9,6 +9,7 @@ export * from './concat';
 export * from './contains';
 export * from './count';
 export * from './distinct';
+export * from './distinct-by';
 export * from './emit';
 export * from './execute';
 export * from './filter';

--- a/src/types/fluent-async-iterable.ts
+++ b/src/types/fluent-async-iterable.ts
@@ -20,6 +20,7 @@ declare module './base' {
     sort: f.AsyncSortFunction<T>;
     sortBy: f.AsyncSortByFunction<T>;
     distinct: f.AsyncDistinctFunction<T>;
+    distinctBy: f.AsyncDistinctByFunction<T>;
     isDistinct: f.AsyncIsDistinctFunction<T>;
     group: f.AsyncGroupFunction<T>;
     count: f.AsyncCountFunction<T>;

--- a/src/types/fluent-iterable.ts
+++ b/src/types/fluent-iterable.ts
@@ -28,6 +28,8 @@ declare module './base' {
     sort: f.SortFunction<T>;
     sortBy: f.SortByFunction<T>;
     distinct: f.DistinctFunction<T>;
+    distinctBy: f.DistinctByFunction<T>;
+    distinctByAsync: f.AsyncDistinctByFunction<T>;
     distinctAsync: f.AsyncDistinctFunction<T>;
     isDistinct: f.IsDistinctFunction<T>;
     isDistinctAsync: f.AsyncIsDistinctFunction<T>;

--- a/src/types/function-types/distinct-by-function.ts
+++ b/src/types/function-types/distinct-by-function.ts
@@ -1,0 +1,25 @@
+import { AsyncMapper, Mapper } from 'augmentative-iterable';
+import { FluentAsyncIterable, FluentIterable } from '../base';
+
+export interface DistinctByFunction<T> {
+  /**
+   * Returns distinct elements from the iterable from a certain list of projections<br>
+   *   Examples:<br>
+   *     * `fluent([{ a: 1, b: 2, c: 1}, { a: 1, b: 2, c: 2}]).distinct()` yields *{ a: 1, b: 2, c: 1 }*<br>
+   * @typeparam R The type of the data the element equality is based on.
+   * @param mappers The projections to use to determine element equality.
+   * @returns The [[FluentIterable]] of the distinct elements.
+   */
+  <R>(...mappers: Array<Mapper<T, R> | keyof T>): FluentIterable<T>;
+}
+export interface AsyncDistinctByFunction<T> {
+  /**
+   * Returns distinct elements from the iterable from a certain list of projections<br>
+   *   Examples:<br>
+   *     * `fluent([{ a: 1, b: 2, c: 1}, { a: 1, b: 2, c: 2}]).distinct()` yields *{ a: 1, b: 2, c: 1 }*<br>
+   * @typeparam R The type of the data the element equality is based on.
+   * @param mappers The projections to use to determine element equality.
+   * @returns The [[FluentIterable]] of the distinct elements.
+   */
+  <R>(...mappers: Array<AsyncMapper<T, R> | keyof T>): FluentAsyncIterable<T>;
+}

--- a/src/types/function-types/index.ts
+++ b/src/types/function-types/index.ts
@@ -8,6 +8,7 @@ export * from './combine-join-function';
 export * from './concat-function';
 export * from './contains-function';
 export * from './count-function';
+export * from './distinct-by-function';
 export * from './distinct-function';
 export * from './emit-function';
 export * from './execute-function';

--- a/test/distinct-by.spec.ts
+++ b/test/distinct-by.spec.ts
@@ -1,0 +1,150 @@
+import { expect } from 'chai';
+import { fluent, fluentAsync } from '../src';
+
+async function* asyncGenerator<T>(list: T[]) {
+  for (const item of list) {
+    yield item;
+  }
+}
+
+describe('distinctBy', () => {
+  describe('iterable', () => {
+    const suite = () => () => {
+      describe('sync', () => {
+        it('empty', () =>
+          expect(fluent([]).distinctBy().toArray()).to.be.empty);
+        it('single mapper', () => {
+          const result = fluent([
+            { a: 1, b: 'c', id: 1 },
+            { a: 1, b: 'd', id: 2 },
+            { a: 1, b: 'c', id: 3 },
+            { a: 2, b: 'c', id: 4 },
+            { a: 2, b: 'c', id: 5 },
+            { a: 3, b: 'c', id: 6 },
+          ])
+            .distinctBy('a')
+            .toArray();
+
+          expect(result).to.eql([
+            { a: 1, b: 'c', id: 1 },
+            { a: 2, b: 'c', id: 4 },
+            { a: 3, b: 'c', id: 6 },
+          ]);
+        });
+        it('multiple mappers', () => {
+          const result = fluent([
+            { a: 1, b: 'c', id: 1 },
+            { a: 1, b: 'd', id: 2 },
+            { a: 1, b: 'c', id: 3 },
+            { a: 2, b: 'c', id: 4 },
+            { a: 2, b: 'c', id: 5 },
+            { a: 3, b: 'c', id: 6 },
+          ])
+            .distinctBy('a', (x) => x.b)
+            .toArray();
+
+          expect(result).to.eql([
+            { a: 1, b: 'c', id: 1 },
+            { a: 1, b: 'd', id: 2 },
+            { a: 2, b: 'c', id: 4 },
+            { a: 3, b: 'c', id: 6 },
+          ]);
+        });
+      });
+      describe('async', () => {
+        it('empty', async () =>
+          expect(await fluent([]).distinctByAsync().toArray()).to.be.empty);
+        it('single mapper', async () => {
+          const result = await fluent([
+            { a: 1, b: 'c', id: 1 },
+            { a: 1, b: 'd', id: 2 },
+            { a: 1, b: 'c', id: 3 },
+            { a: 2, b: 'c', id: 4 },
+            { a: 2, b: 'c', id: 5 },
+            { a: 3, b: 'c', id: 6 },
+          ])
+            .distinctByAsync('a')
+            .toArray();
+
+          expect(result).to.eql([
+            { a: 1, b: 'c', id: 1 },
+            { a: 2, b: 'c', id: 4 },
+            { a: 3, b: 'c', id: 6 },
+          ]);
+        });
+        it('multiple mappers', async () => {
+          const result = await fluent([
+            { a: 1, b: 'c', id: 1 },
+            { a: 1, b: 'd', id: 2 },
+            { a: 1, b: 'c', id: 3 },
+            { a: 2, b: 'c', id: 4 },
+            { a: 2, b: 'c', id: 5 },
+            { a: 3, b: 'c', id: 6 },
+          ])
+            .distinctByAsync('a', (x) => x.b)
+            .toArray();
+
+          expect(result).to.eql([
+            { a: 1, b: 'c', id: 1 },
+            { a: 1, b: 'd', id: 2 },
+            { a: 2, b: 'c', id: 4 },
+            { a: 3, b: 'c', id: 6 },
+          ]);
+        });
+      });
+    };
+    describe('on array', suite());
+  });
+
+  describe('asyncIterable', () => {
+    const suite = () => () => {
+      it('empty', async () =>
+        expect(await fluentAsync(asyncGenerator([])).distinctBy().toArray()).to
+          .be.empty);
+      it('single mapper', async () => {
+        const result = await fluentAsync(
+          asyncGenerator([
+            { a: 1, b: 'c', id: 1 },
+            { a: 1, b: 'd', id: 2 },
+            { a: 1, b: 'c', id: 3 },
+            { a: 2, b: 'c', id: 4 },
+            { a: 2, b: 'c', id: 5 },
+            { a: 3, b: 'c', id: 6 },
+          ]),
+        )
+          .distinctBy('a')
+          .toArray();
+
+        expect(result).to.eql([
+          { a: 1, b: 'c', id: 1 },
+          { a: 2, b: 'c', id: 4 },
+          { a: 3, b: 'c', id: 6 },
+        ]);
+      });
+
+      it('multiple mappers', async () => {
+        const result = await fluentAsync(
+          asyncGenerator([
+            { a: 1, b: 'c', id: 1 },
+            { a: 1, b: 'd', id: 2 },
+            { a: 1, b: 'c', id: 3 },
+            { a: 2, b: 'c', id: 4 },
+            { a: 2, b: 'c', id: 5 },
+            { a: 3, b: 'c', id: 6 },
+          ]),
+        )
+          .distinctBy('a', (x) => x.b)
+          .toArray();
+
+        expect(result).to.eql([
+          { a: 1, b: 'c', id: 1 },
+          { a: 1, b: 'd', id: 2 },
+          { a: 2, b: 'c', id: 4 },
+          { a: 3, b: 'c', id: 6 },
+        ]);
+      });
+    };
+
+    describe('async generator', suite());
+  });
+});

--- a/test/distinct-by.spec.ts
+++ b/test/distinct-by.spec.ts
@@ -8,22 +8,21 @@ async function* asyncGenerator<T>(list: T[]) {
 }
 
 describe('distinctBy', () => {
+  const items = [
+    { a: 1, b: 'c', id: 1 },
+    { a: 1, b: 'd', id: 2 },
+    { a: 1, b: 'c', id: 3 },
+    { a: 2, b: 'c', id: 4 },
+    { a: 2, b: 'c', id: 5 },
+    { a: 3, b: 'c', id: 6 },
+  ];
   describe('iterable', () => {
     const suite = () => () => {
       describe('sync', () => {
         it('empty', () =>
           expect(fluent([]).distinctBy().toArray()).to.be.empty);
         it('single mapper', () => {
-          const result = fluent([
-            { a: 1, b: 'c', id: 1 },
-            { a: 1, b: 'd', id: 2 },
-            { a: 1, b: 'c', id: 3 },
-            { a: 2, b: 'c', id: 4 },
-            { a: 2, b: 'c', id: 5 },
-            { a: 3, b: 'c', id: 6 },
-          ])
-            .distinctBy('a')
-            .toArray();
+          const result = fluent(items).distinctBy('a').toArray();
 
           expect(result).to.eql([
             { a: 1, b: 'c', id: 1 },
@@ -32,14 +31,7 @@ describe('distinctBy', () => {
           ]);
         });
         it('multiple mappers', () => {
-          const result = fluent([
-            { a: 1, b: 'c', id: 1 },
-            { a: 1, b: 'd', id: 2 },
-            { a: 1, b: 'c', id: 3 },
-            { a: 2, b: 'c', id: 4 },
-            { a: 2, b: 'c', id: 5 },
-            { a: 3, b: 'c', id: 6 },
-          ])
+          const result = fluent(items)
             .distinctBy('a', (x) => x.b)
             .toArray();
 
@@ -55,16 +47,7 @@ describe('distinctBy', () => {
         it('empty', async () =>
           expect(await fluent([]).distinctByAsync().toArray()).to.be.empty);
         it('single mapper', async () => {
-          const result = await fluent([
-            { a: 1, b: 'c', id: 1 },
-            { a: 1, b: 'd', id: 2 },
-            { a: 1, b: 'c', id: 3 },
-            { a: 2, b: 'c', id: 4 },
-            { a: 2, b: 'c', id: 5 },
-            { a: 3, b: 'c', id: 6 },
-          ])
-            .distinctByAsync('a')
-            .toArray();
+          const result = await fluent(items).distinctByAsync('a').toArray();
 
           expect(result).to.eql([
             { a: 1, b: 'c', id: 1 },
@@ -73,14 +56,7 @@ describe('distinctBy', () => {
           ]);
         });
         it('multiple mappers', async () => {
-          const result = await fluent([
-            { a: 1, b: 'c', id: 1 },
-            { a: 1, b: 'd', id: 2 },
-            { a: 1, b: 'c', id: 3 },
-            { a: 2, b: 'c', id: 4 },
-            { a: 2, b: 'c', id: 5 },
-            { a: 3, b: 'c', id: 6 },
-          ])
+          const result = await fluent(items)
             .distinctByAsync('a', (x) => x.b)
             .toArray();
 
@@ -102,16 +78,7 @@ describe('distinctBy', () => {
         expect(await fluentAsync(asyncGenerator([])).distinctBy().toArray()).to
           .be.empty);
       it('single mapper', async () => {
-        const result = await fluentAsync(
-          asyncGenerator([
-            { a: 1, b: 'c', id: 1 },
-            { a: 1, b: 'd', id: 2 },
-            { a: 1, b: 'c', id: 3 },
-            { a: 2, b: 'c', id: 4 },
-            { a: 2, b: 'c', id: 5 },
-            { a: 3, b: 'c', id: 6 },
-          ]),
-        )
+        const result = await fluentAsync(asyncGenerator(items))
           .distinctBy('a')
           .toArray();
 
@@ -123,16 +90,7 @@ describe('distinctBy', () => {
       });
 
       it('multiple mappers', async () => {
-        const result = await fluentAsync(
-          asyncGenerator([
-            { a: 1, b: 'c', id: 1 },
-            { a: 1, b: 'd', id: 2 },
-            { a: 1, b: 'c', id: 3 },
-            { a: 2, b: 'c', id: 4 },
-            { a: 2, b: 'c', id: 5 },
-            { a: 3, b: 'c', id: 6 },
-          ]),
-        )
+        const result = await fluentAsync(asyncGenerator(items))
           .distinctBy('a', (x) => x.b)
           .toArray();
 


### PR DESCRIPTION
distinctBy is similar to distinct but supports multiple fields for a composite comparison. It does not support a chooser or a max occurrence, though.

The advantage of this method over distinct is that, when the distinction must to be made over multiple fields, it's much better to do it without any string concatenation, which can add some time complexity to the operation